### PR TITLE
Make the `Watchdog#restart()` method private

### DIFF
--- a/tests/manual/watchdog.js
+++ b/tests/manual/watchdog.js
@@ -14,7 +14,6 @@ import Watchdog from '../../src/watchdog';
 const firstEditorElement = document.getElementById( 'editor-1' );
 const secondEditorElement = document.getElementById( 'editor-2' );
 
-const restartButton = document.getElementById( 'restart' );
 const randomErrorButton = document.getElementById( 'random-error' );
 
 class TypingError {
@@ -55,9 +54,7 @@ const editorConfig = {
 const watchdog1 = Watchdog.for( ClassicEditor );
 window.watchdog1 = watchdog1;
 
-watchdog1.create( firstEditorElement, editorConfig ).then( () => {
-	console.log( 'First editor created.' );
-} );
+watchdog1.create( firstEditorElement, editorConfig );
 
 watchdog1.on( 'error', () => {
 	console.log( 'First editor crashed!' );
@@ -72,9 +69,7 @@ watchdog1.on( 'restart', () => {
 const watchdog2 = Watchdog.for( ClassicEditor );
 window.watchdog2 = watchdog2;
 
-watchdog2.create( secondEditorElement, editorConfig ).then( () => {
-	console.log( 'Second editor created.' );
-} );
+watchdog2.create( secondEditorElement, editorConfig );
 
 watchdog2.on( 'error', () => {
 	console.log( 'Second editor crashed!' );
@@ -82,11 +77,6 @@ watchdog2.on( 'error', () => {
 
 watchdog2.on( 'restart', () => {
 	console.log( 'Second editor restarted.' );
-} );
-
-restartButton.addEventListener( 'click', () => {
-	watchdog1.restart();
-	watchdog2.restart();
 } );
 
 randomErrorButton.addEventListener( 'click', () => {

--- a/tests/manual/watchdog.md
+++ b/tests/manual/watchdog.md
@@ -5,5 +5,3 @@
 1. Click `Simulate a random error` No editor should be restarted.
 
 1. Refresh page and type `1` in the first editor 4 times. The last time the editor should not be restarted.
-
-1. Run `restart both editor`. Both editors should be restarted.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Made the `Watchdog#restart()` method private. Changed the signatures of `Watchdog#create()` and `Watchdog#destroy()`, so now these methods will return empty promises. Closes #13.

