### PR TITLE
Introduce the `Watchdog#state` and the `minimumNonErrorTimePeriod` config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,4 @@ Internal changes only (updated dependencies, documentation, etc.).
 
 ## [10.0.0](https://github.com/ckeditor/ckeditor5-watchdog/tree/v10.0.0) (2019-07-04)
 
-The initial font feature implementation.
+The initial watchdog feature implementation.

--- a/docs/features/watchdog.md
+++ b/docs/features/watchdog.md
@@ -107,6 +107,10 @@ watchdog.state;
 // Listen to state changes.
 watchdog.on( 'change:state' ( evt, name, currentState, prevState ) => {
 	console.log( `Editor changed from ${ currentState } to ${ prevState }` );
+
+	if ( currentState === 'crashedPermanently' ) {
+		watchdog.editor.isReadOnly = true;
+	}
 } );
 
 // An array of editor crashes info.

--- a/docs/features/watchdog.md
+++ b/docs/features/watchdog.md
@@ -47,7 +47,7 @@ watchdog.create( document.querySelector( '#editor' ), {
 In other words, your goal is to create a watchdog instance and make the watchdog create an instance of the editor you want to use. Watchdog will then create a new editor and if it ever crashes restart it by creating a new editor.
 
 <info-box>
-	A new editor instance is created every time the watchdog detects a crash. Thus, the editor instance should not be kept in your application's state. Use the {@link module:watchdog/watchdog~Watchdog#editor Watchdog#editor`} property instead.
+	A new editor instance is created every time the watchdog detects a crash. Thus, the editor instance should not be kept in your application's state. Use the {@link module:watchdog/watchdog~Watchdog#editor `Watchdog#editor`} property instead.
 
 	It also means that any code that should be executed for any new editor instance should be either loaded as an editor plugin or executed in the callbacks defined by {@link module:watchdog/watchdog~Watchdog#setCreator `Watchdog#setCreator()`} and {@link module:watchdog/watchdog~Watchdog#setDestructor `Watchdog#setDestructor()`}. Read more about controlling editor creation/destruction in the next section.
 </info-box>
@@ -85,7 +85,7 @@ watchdog.create( elementOrData, editorConfig );
 
 Other useful {@link module:watchdog/watchdog~Watchdog methods, properties and events}:
 
- ```js
+```js
 watchdog.on( 'error', () => { console.log( 'Editor crashed.' ) } );
 watchdog.on( 'restart', () => { console.log( 'Editor was restarted.' ) } );
 
@@ -95,8 +95,31 @@ watchdog.destroy();
 // The current editor instance.
 watchdog.editor;
 
+// The current state of the editor.
+// The editor might be in one of the following states:
+// * `initializing`
+// * `ready`
+// * `crashed`
+// * `crashedPermanently`
+// This property is observable.
+watchdog.state;
+
+// Listen to state changes.
+watchdog.on( 'change:state' ( evt, name, currentState, prevState ) => {
+	console.log( `Editor changed from ${ currentState } to ${ prevState }` );
+} );
+
+// An array of editor crashes info.
 watchdog.crashes.forEach( crashInfo => console.log( crashInfo ) );
 ```
+
+### Configuration
+
+Both, the {@link module:watchdog/watchdog~Watchdog#constructor `Watchdog#constructor`} and the {@link module:watchdog/watchdog~Watchdog.for `Watchdog.for`} methods accept a {{@link module:watchdog/watchdog~WatchdogConfig configuration object} with the following optional properties:
+
+* `crashNumberLimit` - A threshold specifying the number of editor errors (defaults to `3`). After this limit is reached and the time between last errors is shorter than `minimumNonErrorTimePeriod` the watchdog changes its state to `crashedPermanently` and it stops restarting the editor. This prevents an infinite restart loop.
+* `minimumNonErrorTimePeriod` - An average amount of milliseconds between last editor errors (defaults to 5000). When the period of time between errors is lower than that and the `crashNumberLimit` is also reached the watchdog changes its state to `crashedPermanently` and it stops restarting the editor. This prevents an infinite restart loop.
+* `waitingTime` - A minimum number of milliseconds between saving editor data internally, (defaults to 5000).
 
 ## Limitations
 

--- a/docs/features/watchdog.md
+++ b/docs/features/watchdog.md
@@ -97,10 +97,10 @@ watchdog.editor;
 
 // The current state of the editor.
 // The editor might be in one of the following states:
-// * `initializing`
-// * `ready`
-// * `crashed`
-// * `crashedPermanently`
+// * `initializing` - before the first initialization, and after crashes, before the editor is ready.
+// * `ready` - a state when a user can interact with the editor
+// * `crashed` - a state when an error occurs - it quickly changes to `initializing` or `crashedPermanently` depending on how many and how frequency errors have been caught recently.
+// * `crashedPermanently` - a state when the watchdog stops reacting to errors and keeps the editor crashed.
 // This property is observable.
 watchdog.state;
 

--- a/docs/features/watchdog.md
+++ b/docs/features/watchdog.md
@@ -121,6 +121,14 @@ Both, the {@link module:watchdog/watchdog~Watchdog#constructor `Watchdog#constru
 * `minimumNonErrorTimePeriod` - An average amount of milliseconds between last editor errors (defaults to 5000). When the period of time between errors is lower than that and the `crashNumberLimit` is also reached the watchdog changes its state to `crashedPermanently` and it stops restarting the editor. This prevents an infinite restart loop.
 * `waitingTime` - A minimum number of milliseconds between saving editor data internally, (defaults to 5000).
 
+```js
+const watchdog = new Watchdog( {
+	minimumNonErrorTimePeriod: 2000,
+	crashNumberLimit: 4,
+	waitingTime: 1000
+} )
+```
+
 ## Limitations
 
 The CKEditor 5 watchdog listens to uncaught errors which can be associated with the editor instance created by that watchdog. Currently, these errors are {@link module:utils/ckeditorerror~CKEditorError `CKEditorError` errors} so ones explicitly thrown by the editor (by its internal checks). This means that not every runtime error which crashed the editor can be caught which, in turn, means that not every crash can be detected.

--- a/docs/features/watchdog.md
+++ b/docs/features/watchdog.md
@@ -106,7 +106,7 @@ watchdog.state;
 
 // Listen to state changes.
 watchdog.on( 'change:state' ( evt, name, currentState, prevState ) => {
-	console.log( `Editor changed from ${ currentState } to ${ prevState }` );
+	console.log( `State changed from ${ currentState } to ${ prevState }` );
 
 	if ( currentState === 'crashedPermanently' ) {
 		watchdog.editor.isReadOnly = true;

--- a/docs/features/watchdog.md
+++ b/docs/features/watchdog.md
@@ -97,9 +97,9 @@ watchdog.editor;
 
 // The current state of the editor.
 // The editor might be in one of the following states:
-// * `initializing` - before the first initialization, and after crashes, before the editor is ready.
-// * `ready` - a state when a user can interact with the editor
-// * `crashed` - a state when an error occurs - it quickly changes to `initializing` or `crashedPermanently` depending on how many and how frequency errors have been caught recently.
+// * `initializing` - before the first initialization, and after crashes, before the editor is ready,
+// * `ready` - a state when a user can interact with the editor,
+// * `crashed` - a state when an error occurs - it quickly changes to `initializing` or `crashedPermanently` depending on how many and how frequency errors have been caught recently,
 // * `crashedPermanently` - a state when the watchdog stops reacting to errors and keeps the editor crashed.
 // This property is observable.
 watchdog.state;

--- a/docs/features/watchdog.md
+++ b/docs/features/watchdog.md
@@ -123,13 +123,13 @@ Both, the {@link module:watchdog/watchdog~Watchdog#constructor `Watchdog#constru
 
 * `crashNumberLimit` - A threshold specifying the number of editor errors (defaults to `3`). After this limit is reached and the time between last errors is shorter than `minimumNonErrorTimePeriod` the watchdog changes its state to `crashedPermanently` and it stops restarting the editor. This prevents an infinite restart loop.
 * `minimumNonErrorTimePeriod` - An average amount of milliseconds between last editor errors (defaults to 5000). When the period of time between errors is lower than that and the `crashNumberLimit` is also reached the watchdog changes its state to `crashedPermanently` and it stops restarting the editor. This prevents an infinite restart loop.
-* `waitingTime` - A minimum number of milliseconds between saving editor data internally, (defaults to 5000).
+* `saveInterval` - A minimum number of milliseconds between saving editor data internally, (defaults to 5000). Note that for large documents this might have an impact on the editor performance.
 
 ```js
 const watchdog = new Watchdog( {
 	minimumNonErrorTimePeriod: 2000,
 	crashNumberLimit: 4,
-	waitingTime: 1000
+	saveInterval: 1000
 } )
 ```
 

--- a/docs/features/watchdog.md
+++ b/docs/features/watchdog.md
@@ -100,7 +100,8 @@ watchdog.editor;
 // * `initializing` - before the first initialization, and after crashes, before the editor is ready,
 // * `ready` - a state when a user can interact with the editor,
 // * `crashed` - a state when an error occurs - it quickly changes to `initializing` or `crashedPermanently` depending on how many and how frequency errors have been caught recently,
-// * `crashedPermanently` - a state when the watchdog stops reacting to errors and keeps the editor crashed.
+// * `crashedPermanently` - a state when the watchdog stops reacting to errors and keeps the editor crashed,
+// * `destroyed` - a state when the editor is manually destroyed by the user after calling `watchdog.destroy()`.
 // This property is observable.
 watchdog.state;
 

--- a/docs/features/watchdog.md
+++ b/docs/features/watchdog.md
@@ -123,7 +123,7 @@ Both, the {@link module:watchdog/watchdog~Watchdog#constructor `Watchdog#constru
 
 * `crashNumberLimit` - A threshold specifying the number of editor errors (defaults to `3`). After this limit is reached and the time between last errors is shorter than `minimumNonErrorTimePeriod` the watchdog changes its state to `crashedPermanently` and it stops restarting the editor. This prevents an infinite restart loop.
 * `minimumNonErrorTimePeriod` - An average amount of milliseconds between last editor errors (defaults to 5000). When the period of time between errors is lower than that and the `crashNumberLimit` is also reached the watchdog changes its state to `crashedPermanently` and it stops restarting the editor. This prevents an infinite restart loop.
-* `saveInterval` - A minimum number of milliseconds between saving editor data internally, (defaults to 5000). Note that for large documents this might have an impact on the editor performance.
+* `saveInterval` - A minimum number of milliseconds between saving editor data internally (defaults to 5000). Note that for large documents this might have an impact on the editor performance.
 
 ```js
 const watchdog = new Watchdog( {

--- a/src/watchdog.js
+++ b/src/watchdog.js
@@ -307,7 +307,7 @@ export default class Watchdog {
 	}
 
 	/**
-	 * Checks whether the evt should be handled.
+	 * Checks whether the error event should be handled.
 	 *
 	 * @private
 	 * @param {Event} evt Error event.

--- a/src/watchdog.js
+++ b/src/watchdog.js
@@ -53,14 +53,14 @@ export default class Watchdog {
 		/**
 		 * @private
 		 * @type {Number}
-		 * @see {module:watchdog/watchdog~WatchdogConfig}
+		 * @see module:watchdog/watchdog~WatchdogConfig
 		 */
 		this._crashNumberLimit = typeof config.crashNumberLimit === 'number' ? config.crashNumberLimit : 3;
 
 		/**
 		 * @private
 		 * @type {Number}
-		 * @see {module:watchdog/watchdog~WatchdogConfig}
+		 * @see module:watchdog/watchdog~WatchdogConfig
 		 */
 		this._minimumNonErrorTimePeriod = typeof config.minimumNonErrorTimePeriod === 'number' ? config.minimumNonErrorTimePeriod : 5000;
 

--- a/src/watchdog.js
+++ b/src/watchdog.js
@@ -239,14 +239,14 @@ export default class Watchdog {
 
 	/**
 	 * Destroys the current editor instance by using the destructor passed to the {@link #setDestructor `setDestructor()`} method
-	 * and set state to `destroyed`.
+	 * and sets state to `destroyed`.
 	 *
 	 * @returns {Promise}
 	 */
 	destroy() {
-		return this._destroy().then( () => {
-			this.state = 'destroyed';
-		} );
+		this.state = 'destroyed';
+
+		return this._destroy();
 	}
 
 	/**

--- a/src/watchdog.js
+++ b/src/watchdog.js
@@ -23,16 +23,9 @@ import areConnectedThroughProperties from '@ckeditor/ckeditor5-utils/src/areconn
  */
 export default class Watchdog {
 	/**
-	 * @param {Object} [config] The watchdog plugin configuration.
-	 * @param {Number} [config.crashNumberLimit=3] A threshold specifying the number of editor errors (defaults to `3`).
-	 * After this limit is reached and the `minimumNonErrorTimePeriod` is also reached the editor is not restarted
-	 * by the watchdog and the watchdog fires the {@link #crash `crash` event}. This prevents an infinite restart loop.
-	 * @param {Number} [config.minimumNonErrorTimePeriod=5000] An average amount of milliseconds between last editor errors.
-	 * When the period of time between errors is lower than that and the `crashNumberLimit` is also reached the editor is not
-	 * restarted by the watchdog and the watchdog fires the {@link #crash `crash` event}. This prevents an infinite restart loop.
-	 * @param {Number} [config.waitingTime=5000] A minimum amount of milliseconds between saving editor data internally.
+	 * @param {module:watchdog/watchdog~WatchdogConfig} [config] The watchdog plugin configuration.
 	 */
-	constructor( { crashNumberLimit, minimumNonErrorTimePeriod, waitingTime } = {} ) {
+	constructor( config = {} ) {
 		/**
 		 * An array of crashes saved as an object with the following properties:
 		 *
@@ -65,7 +58,7 @@ export default class Watchdog {
 		 * @private
 		 * @type {Number}
 		 */
-		this._crashNumberLimit = typeof crashNumberLimit === 'number' ? crashNumberLimit : 3;
+		this._crashNumberLimit = typeof config.crashNumberLimit === 'number' ? config.crashNumberLimit : 3;
 
 		/**
 		 * Minumum non-error time period (defaults to `5000`). When the period of time between errors is lower than that,
@@ -73,7 +66,7 @@ export default class Watchdog {
 		 * the {@link #crash `crash` event}. This prevents an infinite restart loop.
 		 *
 		 */
-		this._minimumNonErrorTimePeriod = typeof minimumNonErrorTimePeriod === 'number' ? minimumNonErrorTimePeriod : 5000;
+		this._minimumNonErrorTimePeriod = typeof config.minimumNonErrorTimePeriod === 'number' ? config.minimumNonErrorTimePeriod : 5000;
 
 		/**
 		 * Checks if the event error comes from the editor that is handled by the watchdog (by checking the error context)
@@ -91,7 +84,7 @@ export default class Watchdog {
 		 * @private
 		 * @type {Function}
 		 */
-		this._throttledSave = throttle( this._save.bind( this ), waitingTime || 5000 );
+		this._throttledSave = throttle( this._save.bind( this ), config.waitingTime || 5000 );
 
 		/**
 		 * The current editor instance.
@@ -409,9 +402,10 @@ export default class Watchdog {
 	 *		watchdog.create( elementOrData, config );
 	 *
 	 * @param {*} Editor The editor class.
+	 * @param {module:watchdog/watchdog~WatchdogConfig} [watchdogConfig] The watchdog plugin configuration.
 	 */
-	static for( Editor ) {
-		const watchdog = new Watchdog();
+	static for( Editor, watchdogConfig ) {
+		const watchdog = new Watchdog( watchdogConfig );
 
 		watchdog.setCreator( ( elementOrData, config ) => Editor.create( elementOrData, config ) );
 		watchdog.setDestructor( editor => editor.destroy() );
@@ -434,3 +428,17 @@ export default class Watchdog {
 }
 
 mix( Watchdog, ObservableMixin );
+
+/**
+ * The watchdog plugin configuration.
+ *
+ * @typedef {Object} WatchdogConfig
+ *
+ * @property {Number} [crashNumberLimit=3] A threshold specifying the number of editor errors (defaults to `3`).
+ * After this limit is reached and the `minimumNonErrorTimePeriod` is also reached the editor is not restarted
+ * by the watchdog and the watchdog fires the {@link #crash `crash` event}. This prevents an infinite restart loop.
+ * @property {Number} [minimumNonErrorTimePeriod=5000] An average amount of milliseconds between last editor errors.
+ * When the period of time between errors is lower than that and the `crashNumberLimit` is also reached the editor is not
+ * restarted by the watchdog and the watchdog fires the {@link #crash `crash` event}. This prevents an infinite restart loop.
+ * @property {Number} [waitingTime=5000] A minimum amount of milliseconds between saving editor data internally.
+ */

--- a/src/watchdog.js
+++ b/src/watchdog.js
@@ -435,10 +435,10 @@ mix( Watchdog, ObservableMixin );
  * @typedef {Object} WatchdogConfig
  *
  * @property {Number} [crashNumberLimit=3] A threshold specifying the number of editor errors (defaults to `3`).
- * After this limit is reached and the `minimumNonErrorTimePeriod` is also reached the editor is not restarted
- * by the watchdog and the watchdog fires the {@link #crash `crash` event}. This prevents an infinite restart loop.
- * @property {Number} [minimumNonErrorTimePeriod=5000] An average amount of milliseconds between last editor errors.
- * When the period of time between errors is lower than that and the `crashNumberLimit` is also reached the editor is not
- * restarted by the watchdog and the watchdog fires the {@link #crash `crash` event}. This prevents an infinite restart loop.
- * @property {Number} [waitingTime=5000] A minimum amount of milliseconds between saving editor data internally.
+ * After this limit is reached and the time between last errors is shorter than `minimumNonErrorTimePeriod`
+ * the watchdog changes its state to `crashedPermanently` and it stops restarting the editor. This prevents an infinite restart loop.
+ * @property {Number} [minimumNonErrorTimePeriod=5000] An average amount of milliseconds between last editor errors
+ * (defaults to 5000). When the period of time between errors is lower than that and the `crashNumberLimit` is also reached
+ * the watchdog changes its state to `crashedPermanently` and it stops restarting the editor. This prevents an infinite restart loop.
+ * @property {Number} [waitingTime=5000] A minimum number of milliseconds between saving editor data internally, (defaults to 5000).
  */

--- a/src/watchdog.js
+++ b/src/watchdog.js
@@ -42,7 +42,13 @@ export default class Watchdog {
 		this.crashes = [];
 
 		/**
-		 * Specifies the watchdog state.
+		 * Specifies the state of the editor handled by the watchdog. The state can be one of the following values:
+		 *
+		 * * `initializing` - before the first initialization, and after crashes, before the editor is ready.
+		 * * `ready` - a state when a user can interact with the editor
+		 * * `crashed` - a state when an error occurs - it quickly changes to `initializing` or `crashedPernamently`
+		 * depending on how many and how frequency errors have been caught recently.
+		 * * `crashedPernamently` - a state when the watchdog stops reacting to errors and keeps the editor crashed.
 		 *
 		 * @public
 		 * @observable

--- a/src/watchdog.js
+++ b/src/watchdog.js
@@ -44,11 +44,12 @@ export default class Watchdog {
 		/**
 		 * Specifies the state of the editor handled by the watchdog. The state can be one of the following values:
 		 *
-		 * * `initializing` - before the first initialization, and after crashes, before the editor is ready.
-		 * * `ready` - a state when a user can interact with the editor
+		 * * `initializing` - before the first initialization, and after crashes, before the editor is ready,
+		 * * `ready` - a state when a user can interact with the editor,
 		 * * `crashed` - a state when an error occurs - it quickly changes to `initializing` or `crashedPermanently`
-		 * depending on how many and how frequency errors have been caught recently.
-		 * * `crashedPermanently` - a state when the watchdog stops reacting to errors and keeps the editor crashed.
+		 * depending on how many and how frequency errors have been caught recently,
+		 * * `crashedPermanently` - a state when the watchdog stops reacting to errors and keeps the editor crashed,
+		 * * `destroyed` - a state when the editor is manually destroyed by the user after calling `watchdog.destroy()`
 		 *
 		 * @public
 		 * @observable
@@ -242,6 +243,12 @@ export default class Watchdog {
 	 * @returns {Promise}
 	 */
 	destroy() {
+		return this._destroy().then( () => {
+			this.state = 'destroyed';
+		} );
+	}
+
+	_destroy() {
 		window.removeEventListener( 'error', this._boundErrorHandler );
 		this.stopListening( this._editor.model.document, 'change:data', this._throttledSave );
 
@@ -364,7 +371,7 @@ export default class Watchdog {
 		this._throttledSave.flush();
 
 		return Promise.resolve()
-			.then( () => this.destroy() )
+			.then( () => this._destroy() )
 			.catch( err => console.error( 'An error happened during the editor destructing.', err ) )
 			.then( () => {
 				if ( typeof this._elementOrData === 'string' ) {

--- a/src/watchdog.js
+++ b/src/watchdog.js
@@ -25,14 +25,14 @@ export default class Watchdog {
 	/**
 	 * @param {Object} [config] The watchdog plugin configuration.
 	 * @param {Number} [config.crashNumberLimit=3] A threshold specifying the number of editor errors (defaults to `3`).
-	 * After this limit is reached and the `minNonErrorTimePeriod` is also reached the editor is not restarted
+	 * After this limit is reached and the `minimumNonErrorTimePeriod` is also reached the editor is not restarted
 	 * by the watchdog and the watchdog fires the {@link #crash `crash` event}. This prevents an infinite restart loop.
-	 * @param {Number} [config.minNonErrorTimePeriod=5000] An average amount of milliseconds between last editor errors.
+	 * @param {Number} [config.minimumNonErrorTimePeriod=5000] An average amount of milliseconds between last editor errors.
 	 * When the period of time between errors is lower than that and the `crashNumberLimit` is also reached the editor is not
 	 * restarted by the watchdog and the watchdog fires the {@link #crash `crash` event}. This prevents an infinite restart loop.
 	 * @param {Number} [config.waitingTime=5000] A minimum amount of milliseconds between saving editor data internally.
 	 */
-	constructor( { crashNumberLimit, minNonErrorTimePeriod, waitingTime } = {} ) {
+	constructor( { crashNumberLimit, minimumNonErrorTimePeriod, waitingTime } = {} ) {
 		/**
 		 * An array of crashes saved as an object with the following properties:
 		 *
@@ -58,7 +58,7 @@ export default class Watchdog {
 		this.set( 'state', 'initializing' );
 
 		/**
-		 * Crash number limit (defaults to `3`). After this limit is reached and the {@link #_minNonErrorTimePeriod}
+		 * Crash number limit (defaults to `3`). After this limit is reached and the {@link #_miimumnNonErrorTimePeriod}
 		 * is also reached the editor is not restarted by the watchdog and the watchdog fires
 		 * the {@link #crash `crash` event}. This prevents an infinite restart loop.
 		 *
@@ -73,7 +73,7 @@ export default class Watchdog {
 		 * the {@link #crash `crash` event}. This prevents an infinite restart loop.
 		 *
 		 */
-		this._minNonErrorTimePeriod = typeof minNonErrorTimePeriod === 'number' ? minNonErrorTimePeriod : 5000;
+		this._minimumNonErrorTimePeriod = typeof minimumNonErrorTimePeriod === 'number' ? minimumNonErrorTimePeriod : 5000;
 
 		/**
 		 * Checks if the event error comes from the editor that is handled by the watchdog (by checking the error context)
@@ -348,10 +348,12 @@ export default class Watchdog {
 			return true;
 		}
 
-		return ( (
-			this.crashes[ this.crashes.length - 1 ].date -
-			this.crashes[ this.crashes.length - 1 - this._crashNumberLimit ].date
-		) / this._crashNumberLimit ) > this._minNonErrorTimePeriod;
+		const lastErrorTime = this.crashes[ this.crashes.length - 1 ].date;
+		const firstMeaningfulErrorTime = this.crashes[ this.crashes.length - 1 - this._crashNumberLimit ].date;
+
+		const averageNonErrorTimePeriod = ( lastErrorTime - firstMeaningfulErrorTime ) / this._crashNumberLimit;
+
+		return averageNonErrorTimePeriod > this._minimumNonErrorTimePeriod;
 	}
 
 	/**

--- a/src/watchdog.js
+++ b/src/watchdog.js
@@ -46,9 +46,9 @@ export default class Watchdog {
 		 *
 		 * * `initializing` - before the first initialization, and after crashes, before the editor is ready.
 		 * * `ready` - a state when a user can interact with the editor
-		 * * `crashed` - a state when an error occurs - it quickly changes to `initializing` or `crashedPernamently`
+		 * * `crashed` - a state when an error occurs - it quickly changes to `initializing` or `crashedPermanently`
 		 * depending on how many and how frequency errors have been caught recently.
-		 * * `crashedPernamently` - a state when the watchdog stops reacting to errors and keeps the editor crashed.
+		 * * `crashedPermanently` - a state when the watchdog stops reacting to errors and keeps the editor crashed.
 		 *
 		 * @public
 		 * @observable

--- a/src/watchdog.js
+++ b/src/watchdog.js
@@ -10,7 +10,7 @@
 /* globals console, window */
 
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
-import EmitterMixin from '@ckeditor/ckeditor5-utils/src/emittermixin';
+import ObservableMixin from '@ckeditor/ckeditor5-utils/src/observablemixin';
 import { throttle, cloneDeepWith, isElement } from 'lodash-es';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import areConnectedThroughProperties from '@ckeditor/ckeditor5-utils/src/areconnectedthroughproperties';
@@ -53,9 +53,9 @@ export default class Watchdog {
 		 *
 		 * @public
 		 * @observable
-		 * @type {'initializing'|'ready'|'crashed'|'crashedPermanently'}
+		 * @member {'initializing'|'ready'|'crashed'|'crashedPermanently'} #state
 		 */
-		this.state = 'initializing';
+		this.set( 'state', 'initializing' );
 
 		/**
 		 * Crash number limit (defaults to `3`). After this limit is reached and the {@link #_minNonErrorTimePeriod}
@@ -307,9 +307,9 @@ export default class Watchdog {
 			} );
 
 			this.fire( 'error', { error: evt.error } );
+			this.state = 'crashed';
 
 			if ( this._shouldRestartEditor() ) {
-				this.state = 'crashed';
 				this._restart();
 			} else {
 				this.state = 'crashedPermanently';
@@ -341,7 +341,7 @@ export default class Watchdog {
 	}
 
 	/**
-	 * Checks if the editor should be restared.
+	 * Checks if the editor should be restared or if it should be marked as crashed.
 	 */
 	_shouldRestartEditor() {
 		if ( this.crashes.length <= this._crashNumberLimit ) {
@@ -431,4 +431,4 @@ export default class Watchdog {
 	 */
 }
 
-mix( Watchdog, EmitterMixin );
+mix( Watchdog, ObservableMixin );

--- a/src/watchdog.js
+++ b/src/watchdog.js
@@ -238,7 +238,8 @@ export default class Watchdog {
 	}
 
 	/**
-	 * Destroys the current editor instance by using the destructor passed to the {@link #setDestructor `setDestructor()`} method.
+	 * Destroys the current editor instance by using the destructor passed to the {@link #setDestructor `setDestructor()`} method
+	 * and set state to `destroyed`.
 	 *
 	 * @returns {Promise}
 	 */
@@ -248,6 +249,11 @@ export default class Watchdog {
 		} );
 	}
 
+	/**
+	 * Destroys the current editor instance by using the destructor passed to the {@link #setDestructor `setDestructor()`} method.
+	 *
+	 * @private
+	 */
 	_destroy() {
 		window.removeEventListener( 'error', this._boundErrorHandler );
 		this.stopListening( this._editor.model.document, 'change:data', this._throttledSave );

--- a/src/watchdog.js
+++ b/src/watchdog.js
@@ -53,7 +53,7 @@ export default class Watchdog {
 		 *
 		 * @public
 		 * @observable
-		 * @member {'initializing'|'ready'|'crashed'|'crashedPermanently'} #state
+		 * @member {'initializing'|'ready'|'crashed'|'crashedPermanently'|'destroyed'} #state
 		 */
 		this.set( 'state', 'initializing' );
 

--- a/src/watchdog.js
+++ b/src/watchdog.js
@@ -51,20 +51,16 @@ export default class Watchdog {
 		this.set( 'state', 'initializing' );
 
 		/**
-		 * Crash number limit (defaults to `3`). After this limit is reached and the {@link #_miimumnNonErrorTimePeriod}
-		 * is also reached the editor is not restarted by the watchdog and the watchdog fires
-		 * the {@link #crash `crash` event}. This prevents an infinite restart loop.
-		 *
 		 * @private
 		 * @type {Number}
+		 * @see {module:watchdog/watchdog~WatchdogConfig}
 		 */
 		this._crashNumberLimit = typeof config.crashNumberLimit === 'number' ? config.crashNumberLimit : 3;
 
 		/**
-		 * Minumum non-error time period (defaults to `5000`). When the period of time between errors is lower than that,
-		 * and the {@link #_crashNumberLimit} is also reached the editor is not restarted by the watchdog and the watchdog fires
-		 * the {@link #crash `crash` event}. This prevents an infinite restart loop.
-		 *
+		 * @private
+		 * @type {Number}
+		 * @see {module:watchdog/watchdog~WatchdogConfig}
 		 */
 		this._minimumNonErrorTimePeriod = typeof config.minimumNonErrorTimePeriod === 'number' ? config.minimumNonErrorTimePeriod : 5000;
 

--- a/src/watchdog.js
+++ b/src/watchdog.js
@@ -80,13 +80,13 @@ export default class Watchdog {
 		this._boundErrorHandler = this._handleGlobalErrorEvent.bind( this );
 
 		/**
-		 * Throttled save method. The `save()` method is called the specified `waitingTime` after `throttledSave()` is called,
+		 * Throttled save method. The `save()` method is called the specified `saveInterval` after `throttledSave()` is called,
 		 * unless a new action happens in the meantime.
 		 *
 		 * @private
 		 * @type {Function}
 		 */
-		this._throttledSave = throttle( this._save.bind( this ), config.waitingTime || 5000 );
+		this._throttledSave = throttle( this._save.bind( this ), config.saveInterval || 5000 );
 
 		/**
 		 * The current editor instance.
@@ -442,5 +442,6 @@ mix( Watchdog, ObservableMixin );
  * @property {Number} [minimumNonErrorTimePeriod=5000] An average amount of milliseconds between last editor errors
  * (defaults to 5000). When the period of time between errors is lower than that and the `crashNumberLimit` is also reached
  * the watchdog changes its state to `crashedPermanently` and it stops restarting the editor. This prevents an infinite restart loop.
- * @property {Number} [waitingTime=5000] A minimum number of milliseconds between saving editor data internally, (defaults to 5000).
+ * @property {Number} [saveInterval=5000] A minimum number of milliseconds between saving editor data internally, (defaults to 5000).
+ * Note that for large documents this might have an impact on the editor performance.
  */

--- a/tests/manual/watchdog.html
+++ b/tests/manual/watchdog.html
@@ -1,11 +1,25 @@
 <button id="random-error">Simulate a random `Error`</button>
 
-<div id="editor-1">
-	<h2>Heading 1</h2>
-	<p>Paragraph</p>
+<div class="editor">
+	<div>First editor state: <span id='editor-1-state'></span></div>
+
+	<div id="editor-1">
+		<h2>Heading 1</h2>
+		<p>Paragraph</p>
+	</div>
 </div>
 
-<div id="editor-2">
-	<h2>Heading 1</h2>
-	<p>Paragraph</p>
+<div class="editor">
+	<div>Second editor state: <span id='editor-2-state'></span></div>
+
+	<div id="editor-2">
+		<h2>Heading 1</h2>
+		<p>Paragraph</p>
+	</div>
 </div>
+
+<style>
+.editor {
+	margin-top: 20px;
+}
+</style>

--- a/tests/manual/watchdog.html
+++ b/tests/manual/watchdog.html
@@ -1,7 +1,5 @@
 <button id="random-error">Simulate a random `Error`</button>
 
-<button id="restart">Restart both editors</button>
-
 <div id="editor-1">
 	<h2>Heading 1</h2>
 	<p>Paragraph</p>

--- a/tests/manual/watchdog.js
+++ b/tests/manual/watchdog.js
@@ -44,8 +44,17 @@ const editorConfig = {
 	}
 };
 
-const watchdog1 = createWatchdog( document.getElementById( 'editor-1' ), 'First' );
-const watchdog2 = createWatchdog( document.getElementById( 'editor-2' ), 'Second' );
+const watchdog1 = createWatchdog(
+	document.getElementById( 'editor-1' ),
+	document.getElementById( 'editor-1-state' ),
+	'First'
+);
+
+const watchdog2 = createWatchdog(
+	document.getElementById( 'editor-2' ),
+	document.getElementById( 'editor-2-state' ),
+	'Second'
+);
 
 Object.assign( window, { watchdog1, watchdog2 } );
 
@@ -53,24 +62,28 @@ document.getElementById( 'random-error' ).addEventListener( 'click', () => {
 	throw new Error( 'foo' );
 } );
 
-function createWatchdog( element, which ) {
+function createWatchdog( editorElement, stateElement, name ) {
 	const watchdog = Watchdog.for( ClassicEditor );
 
-	watchdog.create( element, editorConfig );
+	watchdog.create( editorElement, editorConfig );
 
 	watchdog.on( 'error', () => {
-		console.log( `${ which } editor crashed!` );
+		console.log( `${ name } editor crashed!` );
 	} );
 
 	watchdog.on( 'restart', () => {
-		console.log( `${ which } editor restarted.` );
+		console.log( `${ name } editor restarted.` );
 	} );
 
-	watchdog.on( 'change:state', ( evt, name, currentValue, prevValue ) => {
-		console.log( `${ which } watchdog changed state from ${ prevValue } to ${ currentValue }` );
+	watchdog.on( 'change:state', ( evt, paramName, currentValue, prevValue ) => {
+		console.log( `${ name } watchdog changed state from ${ prevValue } to ${ currentValue }` );
+
+		stateElement.innerText = currentValue;
 
 		if ( currentValue === 'crashedPermanently' ) {
 			watchdog.editor.isReadOnly = true;
 		}
 	} );
+
+	stateElement.innerText = watchdog.state;
 }

--- a/tests/manual/watchdog.js
+++ b/tests/manual/watchdog.js
@@ -86,4 +86,6 @@ function createWatchdog( editorElement, stateElement, name ) {
 	} );
 
 	stateElement.innerText = watchdog.state;
+
+	return watchdog;
 }

--- a/tests/manual/watchdog.js
+++ b/tests/manual/watchdog.js
@@ -11,11 +11,6 @@ import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 
 import Watchdog from '../../src/watchdog';
 
-const firstEditorElement = document.getElementById( 'editor-1' );
-const secondEditorElement = document.getElementById( 'editor-2' );
-
-const randomErrorButton = document.getElementById( 'random-error' );
-
 class TypingError {
 	constructor( editor ) {
 		this.editor = editor;
@@ -49,36 +44,33 @@ const editorConfig = {
 	}
 };
 
-// Watchdog 1
+const watchdog1 = createWatchdog( document.getElementById( 'editor-1' ), 'First' );
+const watchdog2 = createWatchdog( document.getElementById( 'editor-2' ), 'Second' );
 
-const watchdog1 = Watchdog.for( ClassicEditor );
-window.watchdog1 = watchdog1;
+Object.assign( window, { watchdog1, watchdog2 } );
 
-watchdog1.create( firstEditorElement, editorConfig );
-
-watchdog1.on( 'error', () => {
-	console.log( 'First editor crashed!' );
-} );
-
-watchdog1.on( 'restart', () => {
-	console.log( 'First editor restarted.' );
-} );
-
-// Watchdog 2
-
-const watchdog2 = Watchdog.for( ClassicEditor );
-window.watchdog2 = watchdog2;
-
-watchdog2.create( secondEditorElement, editorConfig );
-
-watchdog2.on( 'error', () => {
-	console.log( 'Second editor crashed!' );
-} );
-
-watchdog2.on( 'restart', () => {
-	console.log( 'Second editor restarted.' );
-} );
-
-randomErrorButton.addEventListener( 'click', () => {
+document.getElementById( 'random-error' ).addEventListener( 'click', () => {
 	throw new Error( 'foo' );
 } );
+
+function createWatchdog( element, which ) {
+	const watchdog = Watchdog.for( ClassicEditor );
+
+	watchdog.create( element, editorConfig );
+
+	watchdog.on( 'error', () => {
+		console.log( `${ which } editor crashed!` );
+	} );
+
+	watchdog.on( 'restart', () => {
+		console.log( `${ which } editor restarted.` );
+	} );
+
+	watchdog.on( 'change:state', ( evt, name, currentValue, prevValue ) => {
+		console.log( `${ which } watchdog changed state from ${ prevValue } to ${ currentValue }` );
+
+		if ( currentValue === 'crashedPermanently' ) {
+			watchdog.editor.isReadOnly = true;
+		}
+	} );
+}

--- a/tests/manual/watchdog.md
+++ b/tests/manual/watchdog.md
@@ -4,4 +4,6 @@
 
 1. Click `Simulate a random error` No editor should be restarted.
 
-1. Refresh page and type `1` in the first editor 4 times. The last time the editor should not be restarted.
+1. Refresh page and quickly type `1` in the first editor 4 times. After the last error the editor should be crashed and it should not restart.
+
+1. Refresh page and slowly (slower 1 per 5 seconds) type `1` in the first editor 4 times. After the last error the editor should be restarted and it should still work.

--- a/tests/manual/watchdog.md
+++ b/tests/manual/watchdog.md
@@ -6,4 +6,4 @@
 
 1. Refresh page and quickly type `1` in the first editor 4 times. After the last error the editor should be crashed and it should not restart.
 
-1. Refresh page and slowly (slower 1 per 5 seconds) type `1` in the first editor 4 times. After the last error the editor should be restarted and it should still work.
+1. Refresh page and slowly (slower than 1 per 5 seconds) type `1` in the first editor 4 times. After the last error the editor should be restarted and it should still work.

--- a/tests/watchdog.js
+++ b/tests/watchdog.js
@@ -776,7 +776,11 @@ describe( 'Watchdog', () => {
 
 							expect( watchdog.state ).to.equal( 'ready' );
 
-							watchdog.destroy().then( res );
+							watchdog.destroy().then( () => {
+								expect( watchdog.state ).to.equal( 'destroyed' );
+
+								res();
+							} );
 						} );
 					} );
 				} );
@@ -806,22 +810,25 @@ describe( 'Watchdog', () => {
 						setTimeout( () => {
 							window.onerror = originalErrorHandler;
 
-							expect( states ).to.deep.equal( [
-								'ready',
-								'crashed',
-								'initializing',
-								'ready',
-								'crashed',
-								'initializing',
-								'ready',
-								'crashed',
-								'initializing',
-								'ready',
-								'crashed',
-								'crashedPermanently'
-							] );
+							watchdog.destroy().then( () => {
+								expect( states ).to.deep.equal( [
+									'ready',
+									'crashed',
+									'initializing',
+									'ready',
+									'crashed',
+									'initializing',
+									'ready',
+									'crashed',
+									'initializing',
+									'ready',
+									'crashed',
+									'crashedPermanently',
+									'destroyed'
+								] );
 
-							watchdog.destroy().then( res );
+								res();
+							} );
 						} );
 					} );
 				} );

--- a/tests/watchdog.js
+++ b/tests/watchdog.js
@@ -369,7 +369,7 @@ describe( 'Watchdog', () => {
 		} );
 
 		it( 'Watchdog should crash permanently if the `crashNumberLimit` is reached' +
-		' and the average time between errors is lower than `minNonErrorTimePeriod` (default values)', () => {
+		' and the average time between errors is lower than `minimumNonErrorTimePeriod` (default values)', () => {
 			const watchdog = new Watchdog();
 
 			watchdog.setCreator( ( el, config ) => ClassicTestEditor.create( el, config ) );
@@ -406,8 +406,8 @@ describe( 'Watchdog', () => {
 		} );
 
 		it( 'Watchdog should crash permanently if the `crashNumberLimit` is reached' +
-		' and the average time between errors is lower than `minNonErrorTimePeriod` (custom values)', () => {
-			const watchdog = new Watchdog( { crashNumberLimit: 2, minNonErrorTimePeriod: 1000 } );
+		' and the average time between errors is lower than `minimumNonErrorTimePeriod` (custom values)', () => {
+			const watchdog = new Watchdog( { crashNumberLimit: 2, minimumNonErrorTimePeriod: 1000 } );
 
 			watchdog.setCreator( ( el, config ) => ClassicTestEditor.create( el, config ) );
 			watchdog.setDestructor( editor => editor.destroy() );
@@ -442,8 +442,8 @@ describe( 'Watchdog', () => {
 			} );
 		} );
 
-		it( 'Watchdog should not crash permantently when average time between errors is longer than `minNonErrorTimePeriod`', () => {
-			const watchdog = new Watchdog( { crashNumberLimit: 2, minNonErrorTimePeriod: 0 } );
+		it( 'Watchdog should not crash permantently when average time between errors is longer than `minimumNonErrorTimePeriod`', () => {
+			const watchdog = new Watchdog( { crashNumberLimit: 2, minimumNonErrorTimePeriod: 0 } );
 
 			watchdog.setCreator( ( el, config ) => ClassicTestEditor.create( el, config ) );
 			watchdog.setDestructor( editor => editor.destroy() );
@@ -459,10 +459,10 @@ describe( 'Watchdog', () => {
 			window.onerror = undefined;
 
 			return watchdog.create( element ).then( () => {
-				setTimeout( () => throwCKEditorError( 'foo1', watchdog.editor ) );
-				setTimeout( () => throwCKEditorError( 'foo2', watchdog.editor ) );
-				setTimeout( () => throwCKEditorError( 'foo3', watchdog.editor ) );
-				setTimeout( () => throwCKEditorError( 'foo4', watchdog.editor ) );
+				setTimeout( () => throwCKEditorError( 'foo1', watchdog.editor ), 5 );
+				setTimeout( () => throwCKEditorError( 'foo2', watchdog.editor ), 10 );
+				setTimeout( () => throwCKEditorError( 'foo3', watchdog.editor ), 15 );
+				setTimeout( () => throwCKEditorError( 'foo4', watchdog.editor ), 20 );
 
 				return new Promise( res => {
 					setTimeout( () => {
@@ -473,7 +473,7 @@ describe( 'Watchdog', () => {
 						window.onerror = originalErrorHandler;
 
 						watchdog.destroy().then( res );
-					} );
+					}, 20 );
 				} );
 			} );
 		} );


### PR DESCRIPTION
Feature: Introduced the observable `Watchdog#state` property. Introduced the `minimumNonErrorTimePeriod` configuration which defaults to 5 seconds and will be used to prevent infinite restart loops while allowing a larger number of random crashes as long as they do not happen too often. Renamed `waitingTime` configuration option to `saveInterval`. Closes #7. Closes #15.

BREAKING CHANGE: Renamed `waitingTime` configuration option to `saveInterval`.

---

### Additional information

The `Watchdog#state` prop will be able to have the following values: 

* `initializing` - before the first initialization, and after crashes, before the editor is ready.
* `ready` - a state when you can interact with the editor
* `crashed` - a state when an error occurs - it quickly changes to `initializing` or `crashedPernamently` depending on how many and how frequency errors have been caught in the past.  
* `crashedPernamently` - a state when the watchdog stops reacting to errors and keeps the editor crashed. 

