### PR TITLE
Added the `Watchdog#_now()` method.

### DIFF
--- a/src/watchdog.js
+++ b/src/watchdog.js
@@ -70,7 +70,7 @@ export default class Watchdog {
 		 *
 		 * @protected
 		 */
-		this._now = () => Date.now();
+		this._now = Date.now;
 
 		/**
 		 * @private

--- a/src/watchdog.js
+++ b/src/watchdog.js
@@ -95,7 +95,10 @@ export default class Watchdog {
 		 * @private
 		 * @type {Function}
 		 */
-		this._throttledSave = throttle( this._save.bind( this ), config.saveInterval || 5000 );
+		this._throttledSave = throttle(
+			this._save.bind( this ),
+			typeof config.saveInterval === 'number' ? config.saveInterval : 5000
+		);
 
 		/**
 		 * The current editor instance.
@@ -266,7 +269,7 @@ export default class Watchdog {
 		window.removeEventListener( 'error', this._boundErrorHandler );
 		this.stopListening( this._editor.model.document, 'change:data', this._throttledSave );
 
-		// Save data if there are remaining changes.
+		// Save data if there is a remaining editor data change.
 		this._throttledSave.flush();
 
 		return Promise.resolve()
@@ -284,6 +287,8 @@ export default class Watchdog {
 	 */
 	_save() {
 		const version = this._editor.model.document.version;
+
+		console.log( 'saving' );
 
 		// Change may not produce an operation, so the document's version
 		// can be the same after that change.

--- a/src/watchdog.js
+++ b/src/watchdog.js
@@ -266,6 +266,9 @@ export default class Watchdog {
 		window.removeEventListener( 'error', this._boundErrorHandler );
 		this.stopListening( this._editor.model.document, 'change:data', this._throttledSave );
 
+		// Save data if there are remaining changes.
+		this._throttledSave.flush();
+
 		return Promise.resolve()
 			.then( () => this._destructor( this._editor ) )
 			.then( () => {
@@ -382,7 +385,6 @@ export default class Watchdog {
 	 */
 	_restart() {
 		this.state = 'initializing';
-		this._throttledSave.flush();
 
 		return Promise.resolve()
 			.then( () => this._destroy() )

--- a/src/watchdog.js
+++ b/src/watchdog.js
@@ -65,6 +65,14 @@ export default class Watchdog {
 		this._crashNumberLimit = typeof config.crashNumberLimit === 'number' ? config.crashNumberLimit : 3;
 
 		/**
+		 * Returns the result of `Date.now()` call. It can be overridden in tests to mock time as the popular
+		 * approaches like `sinon.useFakeTimers()` does not work well with error handling.
+		 *
+		 * @protected
+		 */
+		this._now = () => Date.now();
+
+		/**
 		 * @private
 		 * @type {Number}
 		 * @see module:watchdog/watchdog~WatchdogConfig
@@ -311,7 +319,7 @@ export default class Watchdog {
 				source: evt.source,
 				lineno: evt.lineno,
 				colno: evt.colno,
-				date: Date.now()
+				date: this._now()
 			} );
 
 			this.fire( 'error', { error: evt.error } );

--- a/src/watchdog.js
+++ b/src/watchdog.js
@@ -288,8 +288,6 @@ export default class Watchdog {
 	_save() {
 		const version = this._editor.model.document.version;
 
-		console.log( 'saving' );
-
 		// Change may not produce an operation, so the document's version
 		// can be the same after that change.
 		if ( version === this._lastDocumentVersion ) {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: The editor data will be saved correctly after the `destroy()` method is called. Added the protected `Watchdog#_now()` method that allows for time-based testing of the error handling mechanism. Closes #17. Closes #19.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
