### PR TITLE
Add unhandled promise rejection error handling

### DIFF
--- a/src/watchdog.js
+++ b/src/watchdog.js
@@ -363,7 +363,7 @@ export default class Watchdog {
 	 * Checks whether the error should be handled.
 	 *
 	 * @private
-	 * @param {Error} error Error event.
+	 * @param {Error} error Error
 	 */
 	_shouldReactToError( error ) {
 		return (

--- a/src/watchdog.js
+++ b/src/watchdog.js
@@ -32,9 +32,9 @@ export default class Watchdog {
 		 * * `message`: `String`,
 		 * * `stack`: `String`,
 		 * * `date`: `Number`,
-		 * * `source`: `String | undefined`,
-		 * * `lineno`: `String | undefined`,
-		 * * `colno`: `String` | undefined,
+		 * * `filename`: `String | undefined`,
+		 * * `lineno`: `Number | undefined`,
+		 * * `colno`: `Number` | undefined,
 		 *
 		 * @public
 		 * @readonly
@@ -327,8 +327,8 @@ export default class Watchdog {
 				message: error.message,
 				stack: error.stack,
 
-				// `evt.source`, `evt.lineno` and `evt.colno` are available only in ErrorEvent events
-				source: evt.source,
+				// `evt.filename`, `evt.lineno` and `evt.colno` are available only in ErrorEvent events
+				filename: evt.filename,
 				lineno: evt.lineno,
 				colno: evt.colno,
 				date: Date.now()

--- a/src/watchdog.js
+++ b/src/watchdog.js
@@ -34,7 +34,7 @@ export default class Watchdog {
 		 * * `date`: `Number`,
 		 * * `filename`: `String | undefined`,
 		 * * `lineno`: `Number | undefined`,
-		 * * `colno`: `Number` | undefined,
+		 * * `colno`: `Number | undefined`,
 		 *
 		 * @public
 		 * @readonly

--- a/src/watchdog.js
+++ b/src/watchdog.js
@@ -88,7 +88,6 @@ export default class Watchdog {
 					this._handleError( evt.reason, evt );
 				}
 			} else {
-				// TODO: what throw 'foo' will do?
 				this._handleError( evt.error, evt );
 			}
 		};
@@ -316,7 +315,7 @@ export default class Watchdog {
 	 * @private
 	 * @fires error
 	 * @param {Error} error Error.
-	 * @param {ErrorEvent} evt Error event.
+	 * @param {ErrorEvent|PromiseRejectionEvent} evt Error event.
 	 */
 	_handleError( error, evt ) {
 		if ( error.is && error.is( 'CKEditorError' ) && error.context === undefined ) {
@@ -328,7 +327,7 @@ export default class Watchdog {
 				message: error.message,
 				stack: error.stack,
 
-				// evt.source, evt.lineno and evt.colno are available only in ErrorEvent
+				// `evt.source`, `evt.lineno` and `evt.colno` are available only in ErrorEvent events
 				source: evt.source,
 				lineno: evt.lineno,
 				colno: evt.colno,

--- a/tests/watchdog.js
+++ b/tests/watchdog.js
@@ -702,7 +702,7 @@ describe( 'Watchdog', () => {
 		let unhandledRejectionEventSupported;
 
 		before( () => {
-			return doesEnvSupportUnhandledRejectionEvent()
+			return isUnhandledRejectionEventSupported()
 				.then( val => {
 					unhandledRejectionEventSupported = val;
 				} );
@@ -920,7 +920,7 @@ function throwCKEditorError( name, context ) {
 
 // Feature detection works as a race condition - if the `unhandledrejection` event
 // is supported then the listener should be called first. Otherwise the timeout will be reached.
-function doesEnvSupportUnhandledRejectionEvent() {
+function isUnhandledRejectionEventSupported() {
 	return new Promise( res => {
 		window.addEventListener( 'unhandledrejection', function listener() {
 			res( true );

--- a/tests/watchdog.js
+++ b/tests/watchdog.js
@@ -918,6 +918,8 @@ function throwCKEditorError( name, context ) {
 	throw new CKEditorError( name, context );
 }
 
+// Feature detection works as a race condition - if the `unhandledrejection` event
+// is supported then the listener should be called first. Otherwise the timeout will be reached.
 function doesEnvSupportUnhandledRejectionEvent() {
 	return new Promise( res => {
 		window.addEventListener( 'unhandledrejection', function listener() {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Added unhandled promise rejection error handling. Fixed objects in the `crashed` array Closes #3.

---

### Additional information

From now all unhandled promise rejections will be caught by the watchdog, and if such error comes from the watchdog's editor the watchdog will restart it.

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*

Requires https://github.com/ckeditor/ckeditor5-dev/pull/539.
