### PR TITLE
Fixed tests leaking editor instance / DOM element

### DIFF
--- a/tests/watchdog.js
+++ b/tests/watchdog.js
@@ -12,7 +12,6 @@ import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import { expectToThrowCKEditorError } from '@ckeditor/ckeditor5-utils/tests/_utils/utils';
 import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/htmldataprocessor';
-import { destroyEditorOrphans } from '@ckeditor/ckeditor5-core/tests/_utils/cleanup';
 
 describe( 'Watchdog', () => {
 	let element;
@@ -721,6 +720,22 @@ describe( 'Watchdog', () => {
 				} );
 			} );
 		} );
+
+		// Searches for orphaned editors based on DOM.
+		//
+		// This is useful if in your tests you have no access to editor, instance because editor
+		// creation method doesn't complete in a graceful manner.
+		function destroyEditorOrphans() {
+			const promises = [];
+
+			for ( const editableOrphan of document.querySelectorAll( '.ck-editor__editable' ) ) {
+				if ( editableOrphan.ckeditorInstance ) {
+					promises.push( editableOrphan.ckeditorInstance.destroy() );
+				}
+			}
+
+			return Promise.all( promises );
+		}
 	} );
 
 	describe( 'async error handling', () => {

--- a/tests/watchdog.js
+++ b/tests/watchdog.js
@@ -59,13 +59,6 @@ describe( 'Watchdog', () => {
 			);
 		} );
 
-		it( 'should not throw an error when the destructor is not defined', () => {
-			const watchdog = new Watchdog();
-			watchdog.setCreator( ( el, config ) => ClassicTestEditor.create( el, config ) );
-
-			expect( () => watchdog.create() ).to.not.throw();
-		} );
-
 		it( 'should properly copy the config', () => {
 			const watchdog = new Watchdog();
 			watchdog.setCreator( ( el, config ) => ClassicTestEditor.create( el, config ) );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Tests: Fixed tests leaking editor instances / DOM elements. See ckeditor/ckeditor5#6002.

---

### Additional information

⚠ This PR requires https://github.com/ckeditor/ckeditor5-core/pull/207 to pass properly ⚠

This is actually the most tricky test suite to be fixed in entire bunch.

During the implementation I found out that one watchdog case doesn't pass the test it is supposed to pass (#6042). I believe the test at this point should be simply removed, but I want to get a confirmation in #6042.

For a complete list of PRs see https://github.com/ckeditor/ckeditor5/issues/6002#issuecomment-567834563.