### PR TITLE
[WIP] Introduce the ContextWatchdog

### DIFF
--- a/docs/features/watchdog.md
+++ b/docs/features/watchdog.md
@@ -186,10 +186,12 @@ await watchdog.add( [ {
 } ] );
 ```
 
-The Watchdog will keep the context and editor instances running
-that are added via the {@link module:watchdog/contextwatchdog~ContextWatchdog#add `ContextWatchdog#add` method}. This method can be called multiple times during the `ContextWatchdog` lifetime.
+<info-box>
+	The Watchdog will keep the context and item instances running
+	that are added via the {@link module:watchdog/contextwatchdog~ContextWatchdog#add `ContextWatchdog#add` method}. This method can be called multiple times during the `ContextWatchdog` lifetime.
 
-To destroy one of the editor instances use the {@link module:watchdog/contextwatchdog~ContextWatchdog#remove `ContextWatchdog#remove` method}. This method can be called multiple times during the `ContextWatchdog` lifetime as well.
+	To destroy one of the item instances use the {@link module:watchdog/contextwatchdog~ContextWatchdog#remove `ContextWatchdog#remove` method}. This method can be called multiple times during the `ContextWatchdog` lifetime as well.
+</info-box>
 
 ```js
 await watchdog.remove( [ 'editor1', 'editor2' ] );
@@ -201,7 +203,7 @@ await watchdog.remove( 'editor2' );
 
 <info-box>
 	Examples presents the "synchronous way" of the integration with the context watchdog feature, however it's not needed to wait for the promises returned by the `create()`, `add()` and `remove()` methods. There might be a need
-	to create and destroy editors dynamically with shared context and that's can be easily achieved as all promises operating on the internal API will be chained.
+	to create and destroy items dynamically with shared context and that's can be easily achieved as all promises operating on the internal API will be chained.
 </info-box>
 
 #### Context watchdog API
@@ -231,7 +233,7 @@ watchdog.setDestructor( async context => {
 // Initializing the context watchdog with the context configuration.
 await watchdog.create( contextConfig );
 
-// Adding editor configuration (or an array of editor configurations).
+// Adding item configuration (or an array of item configurations).
 await watchdog.add( {
 	id: 'editor1',
 	type: 'editor',
@@ -241,7 +243,7 @@ await watchdog.add( {
 	destructor: destroyEditor,
 } );
 
-// Removing and destroy given editor.
+// Removing and destroy given item.
 await watchdog.remove( [ 'editor1' ] );
 
 // Getting given item instance.
@@ -254,11 +256,11 @@ const editor1State = watchdog.getState( 'editor1' );
 const contextState = watchdog.state;
 
 // Listening to an event fired when the context watchdog catches the context-related error.
-// Note that the editor errors are not re-fired in the `ContextWatchdog#error`.
+// Note that the item errors are not re-fired in the `ContextWatchdog#error`.
 watchdog.on( 'error', () => {} );
 
 // Listening to an event fired when the context is set back to the `ready` state (after it was in `error` state).
-// Similarly, this event is not thrown for internal editor instances.
+// Similarly, this event is not thrown for internal item restarts.
 watchdog.on( 'restart', () => {} );
 ```
 
@@ -279,7 +281,7 @@ const editorWatchdog = new EditorWatchdog( ClassicEditor, {
 ```
 
 <info-box>
-	Note that the context watchdog passes this configuration to the added editors.
+	Note that the context watchdog passes its configuration to the added editors.
 </info-box>
 
 ## Limitations

--- a/docs/features/watchdog.md
+++ b/docs/features/watchdog.md
@@ -130,23 +130,7 @@ watchdog.on( 'change:state' ( evt, name, currentState, prevState ) => {
 watchdog.crashes.forEach( crashInfo => console.log( crashInfo ) );
 ```
 
-#### Configuration
-
-Both, the {@link module:watchdog/watchdog~Watchdog#constructor `Watchdog#constructor`} and the {@link module:watchdog/watchdog~Watchdog.for `Watchdog.for`} methods accept a {{@link module:watchdog/watchdog~WatchdogConfig configuration object} with the following optional properties:
-
-* `crashNumberLimit` - A threshold specifying the number of editor errors (defaults to `3`). After this limit is reached and the time between last errors is shorter than `minimumNonErrorTimePeriod` the watchdog changes its state to `crashedPermanently` and it stops restarting the editor. This prevents an infinite restart loop.
-* `minimumNonErrorTimePeriod` - An average amount of milliseconds between last editor errors (defaults to 5000). When the period of time between errors is lower than that and the `crashNumberLimit` is also reached the watchdog changes its state to `crashedPermanently` and it stops restarting the editor. This prevents an infinite restart loop.
-* `saveInterval` - A minimum number of milliseconds between saving editor data internally (defaults to 5000). Note that for large documents this might have an impact on the editor performance.
-
-```js
-const watchdog = new Watchdog( {
-	minimumNonErrorTimePeriod: 2000,
-	crashNumberLimit: 4,
-	saveInterval: 1000
-} )
-```
-
-## Context watchdog
+### Context watchdog
 
 <info-box>
 	Note: the ContextWatchdog can be used only with an {@link builds/guides/integration/advanced-setup#scenario-2-building-from-source editor built from source}.
@@ -213,7 +197,7 @@ watchdog.remove( [ 'editor1' ] );
 	Note that the above examples does not use promises returning by the context watchdog methods while these methods are asynchronous. You should not depend on these promises because they are resolved only once while your component might be restarted multiple times internally causing watchdog to unmount the editor and to mount again. Read further below for more information about events and watchdog states.
 </info-box>
 
-### Context watchdog API
+#### Context watchdog API
 
 The ContextWatchdog feature provides the following API:
 
@@ -263,11 +247,32 @@ const editor1State = watchdog.getState( 'editor1' );
 // Context state.
 const contextState = watchdog.state;
 
-// Events
+// An event fired when the context watchdog catches the context-related error.
+// Note that the editor errors are not re-fired in the `ContextWatchdog#error`.
 watchdog.on( 'error', () => {} );
 
+// An event fired when the context is back to the `ready` state.
+// Similarly, this event is not thrown for internal editor instances.
 watchdog.on( 'restart', () => {} );
 ```
+
+## Configuration
+
+Both, the {@link module:watchdog/watchdog~Watchdog#constructor `Watchdog#constructor`} and the {@link module:watchdog/watchdog~Watchdog.for `Watchdog.for`} methods accept a {{@link module:watchdog/watchdog~WatchdogConfig configuration object} with the following optional properties:
+
+* `crashNumberLimit` - A threshold specifying the number of editor errors (defaults to `3`). After this limit is reached and the time between last errors is shorter than `minimumNonErrorTimePeriod` the watchdog changes its state to `crashedPermanently` and it stops restarting the editor. This prevents an infinite restart loop.
+* `minimumNonErrorTimePeriod` - An average amount of milliseconds between last editor errors (defaults to 5000). When the period of time between errors is lower than that and the `crashNumberLimit` is also reached the watchdog changes its state to `crashedPermanently` and it stops restarting the editor. This prevents an infinite restart loop.
+* `saveInterval` - A minimum number of milliseconds between saving editor data internally (defaults to 5000). Note that for large documents this might have an impact on the editor performance.
+
+```js
+const watchdog = new Watchdog( {
+	minimumNonErrorTimePeriod: 2000,
+	crashNumberLimit: 4,
+	saveInterval: 1000
+} )
+```
+
+Note that the ContextWatchdog spreads its configuration to the added items.
 
 ## Limitations
 

--- a/docs/features/watchdog.md
+++ b/docs/features/watchdog.md
@@ -43,7 +43,7 @@ import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
 import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
 
 // Create a watchdog for the given editor type.
-const watchdog = EditorWatchdog.for( ClassicEditor );
+const watchdog = new EditorWatchdog( ClassicEditor );
 
 // Create a new editor instance.
 watchdog.create( document.querySelector( '#editor' ), {
@@ -263,21 +263,21 @@ watchdog.on( 'restart', () => {} );
 
 ## Configuration
 
-Both, the {@link module:watchdog/watchdog~Watchdog#constructor `Watchdog#constructor`} and the {@link module:watchdog/watchdog~Watchdog.for `Watchdog.for`} methods accept a {{@link module:watchdog/watchdog~WatchdogConfig configuration object} with the following optional properties:
+Both, {@link module:watchdog/editorwatchdog~EditorWatchdog#constructor `EditorWatchdog`} and {@link module:watchdog/contextwatchdog~ContextWatchdog#constructor `ContextWatchdog`} constructors accept a {{@link module:watchdog/watchdog~WatchdogConfig configuration object} as the second argument with the following optional properties:
 
 * `crashNumberLimit` - A threshold specifying the number of editor errors (defaults to `3`). After this limit is reached and the time between last errors is shorter than `minimumNonErrorTimePeriod` the watchdog changes its state to `crashedPermanently` and it stops restarting the editor. This prevents an infinite restart loop.
 * `minimumNonErrorTimePeriod` - An average amount of milliseconds between last editor errors (defaults to 5000). When the period of time between errors is lower than that and the `crashNumberLimit` is also reached the watchdog changes its state to `crashedPermanently` and it stops restarting the editor. This prevents an infinite restart loop.
 * `saveInterval` - A minimum number of milliseconds between saving editor data internally (defaults to 5000). Note that for large documents this might have an impact on the editor performance.
 
 ```js
-const watchdog = new Watchdog( {
+const editorWatchdog = new EditorWatchdog( ClassicEditor, {
 	minimumNonErrorTimePeriod: 2000,
 	crashNumberLimit: 4,
 	saveInterval: 1000
 } )
 ```
 
-Note that the ContextWatchdog spreads its configuration to the added items.
+Note that the context watchdog passes this configuration to the added editors.
 
 ## Limitations
 

--- a/docs/features/watchdog.md
+++ b/docs/features/watchdog.md
@@ -208,10 +208,10 @@ await watchdog.remove( 'editor2' );
 The context watchdog feature provides the following API:
 
 ```js
-// Create watchdog that will use the `Context` class and given configuration.
+// Creating watchdog that will use the `Context` class and given configuration.
 const watchdog = new ContextWatchdog( Context, watchdogConfig );
 
-// Set a custom creator.
+// Setting a custom creator.
 watchdog.setCreator( async config => {
 	const context = await Context.create( config ) );
 
@@ -220,17 +220,17 @@ watchdog.setCreator( async config => {
 	return context;
 } );
 
-// Set a custom destructor.
+// Setting a custom destructor.
 watchdog.setDestructor( async context => {
 	// Do something before destroy.
 
 	await context.destroy();
 } );
 
-// Initialize the context watchdog with the context configuration.
+// Initializing the context watchdog with the context configuration.
 await watchdog.create( contextConfig );
 
-// Add editor configuration (or an array of editor configurations).
+// Adding editor configuration (or an array of editor configurations).
 await watchdog.add( {
 	id: 'editor1',
 	type: 'editor',
@@ -240,23 +240,23 @@ await watchdog.add( {
 	destructor: destroyEditor,
 } );
 
-// Remove and destroy given editor.
+// Removing and destroy given editor.
 await watchdog.remove( [ 'editor1' ] );
 
-// Get given item instance.
+// Getting given item instance.
 const editor1 = watchdog.get( 'editor1' );
 
-// Get given item state.
+// Getting given item state.
 const editor1State = watchdog.getState( 'editor1' );
 
-// Get the context state.
+// Getting the context state.
 const contextState = watchdog.state;
 
-// An event fired when the context watchdog catches the context-related error.
+// Listening to an event fired when the context watchdog catches the context-related error.
 // Note that the editor errors are not re-fired in the `ContextWatchdog#error`.
 watchdog.on( 'error', () => {} );
 
-// An event fired when the context is set back to the `ready` state (after it was in `error` state).
+// Listening to an event fired when the context is set back to the `ready` state (after it was in `error` state).
 // Similarly, this event is not thrown for internal editor instances.
 watchdog.on( 'restart', () => {} );
 ```

--- a/docs/features/watchdog.md
+++ b/docs/features/watchdog.md
@@ -285,10 +285,10 @@ await watchdog.remove( 'editor1' );
 await watchdog.remove( [ 'editor1', 'editor2', ... ] );
 
 // Getting given item instance.
-const editor1 = watchdog.get( 'editor1' );
+const editor1 = watchdog.getItem( 'editor1' );
 
 // Getting given item state.
-const editor1State = watchdog.getState( 'editor1' );
+const editor1State = watchdog.getItemState( 'editor1' );
 
 // Getting the context state.
 const contextState = watchdog.state;

--- a/docs/features/watchdog.md
+++ b/docs/features/watchdog.md
@@ -154,34 +154,36 @@ import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
 import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
 import Context from '@ckeditor/ckeditor5-core/src/context';
 
-// Create a watchdog for the context and pass the context configuration:
-const watchdog = ContextWatchdog.for( Context, {
-	plugins: [],
-
-	// Rest of the configuration.
+// Create a watchdog for the context and pass the `Context` class with optional watchdog configuration:
+const watchdog = new ContextWatchdog( Context, {
+	crashNumberLimit: 10
 } );
+
+// Initialize it with the context configuration:
+await watchdog.create( {
+	plugins: []
+} )
 
 // Add editor instances:
-watchdog.add( {
-	editor1: {
-		type: 'editor',
-		sourceElementOrData: document.querySelector( '#editor' ),
-		config: {
-			plugins: [ Essentials, Paragraph, Bold, Italic ],
-			toolbar: [ 'bold', 'italic', 'alignment' ]
-		},
-		creator: ( element, config ) => ClassicEditor.create( element, config )
+await watchdog.add( [ {
+	id: 'editor1',
+	type: 'editor',
+	sourceElementOrData: document.querySelector( '#editor' ),
+	config: {
+		plugins: [ Essentials, Paragraph, Bold, Italic ],
+		toolbar: [ 'bold', 'italic', 'alignment' ]
 	},
-	editor2: {
-		type: 'editor',
-		sourceElementOrData: document.querySelector( '#editor' ),
-		config: {
-			plugins: [ Essentials, Paragraph, Bold, Italic ],
-			toolbar: [ 'bold', 'italic', 'alignment' ]
-		},
-		creator: ( element, config ) => ClassicEditor.create( element, config )
+	creator: ( element, config ) => ClassicEditor.create( element, config )
+}, {
+	id: 'editor2',
+	type: 'editor',
+	sourceElementOrData: document.querySelector( '#editor' ),
+	config: {
+		plugins: [ Essentials, Paragraph, Bold, Italic ],
+		toolbar: [ 'bold', 'italic', 'alignment' ]
 	},
-} );
+	creator: ( element, config ) => ClassicEditor.create( element, config )
+} ] );
 ```
 
 The Watchdog will keep the context and editor instances running
@@ -190,7 +192,11 @@ that are added via the {@link module:watchdog/contextwatchdog~ContextWatchdog#ad
 To destroy one of the editor instances use the {@link module:watchdog/contextwatchdog~ContextWatchdog#remove `ContextWatchdog#remove` method}. This method can be called multiple times during the `ContextWatchdog` lifetime as well.
 
 ```js
-watchdog.remove( [ 'editor1' ] );
+await watchdog.remove( [ 'editor1', 'editor2' ] );
+
+// Or
+await watchdog.remove( 'editor1' );
+await watchdog.remove( 'editor2' );
 ```
 
 <info-box>
@@ -202,12 +208,10 @@ watchdog.remove( [ 'editor1' ] );
 The ContextWatchdog feature provides the following API:
 
 ```js
-// A simple initialization with default Context creation and destruction functions:
-const watchdog = ContextWatchdog.for( Context, contextConfig, watchdogConfig )
+// Create watchdog that will use the `Context` class and given configuration.
+const watchdog = new ContextWatchdog( Context, watchdogConfig );
 
-// An advanced initialization where custom creation and destruction functions can be passed:
-const watchdog = new ContextWatchdog( contextConfig, watchdogConfig )
-
+// Set a custom creator.
 watchdog.setCreator( async config => {
 	const context = await Context.create( config ) );
 
@@ -216,35 +220,36 @@ watchdog.setCreator( async config => {
 	return context;
 } );
 
+// Set a custom destructor.
 watchdog.setDestructor( async context => {
 	// Do something before destroy.
 
 	await context.destroy();
 } );
 
-watchdog.create();
+// Initialize the context watchdog with the context configuration.
+await watchdog.create( contextConfig );
 
-// Adding, removing and getting item instances:
-watchdog.add( {
-	editor1: {
-		type: 'editor',
-		sourceElementOrData: editorSourceElementOrEditorData
-		config: editorConfig,
-		creator: createEditor,
-		destructor: destroyEditor,
-	},
-	// Possibly more items.
+// Add editor configuration.
+await watchdog.add( {
+	id: 'editor1',
+	type: 'editor',
+	sourceElementOrData: editorSourceElementOrEditorData
+	config: editorConfig,
+	creator: createEditor,
+	destructor: destroyEditor,
 } );
 
-watchdog.remove( [ 'editor1' ] );
+// Remove and destroy given editor.
+await watchdog.remove( [ 'editor1' ] );
 
-// Given item instance.
+// Get given item instance.
 const editor1 = watchdog.get( 'editor1' );
 
-// Given item state.
+// Get given item state.
 const editor1State = watchdog.getState( 'editor1' );
 
-// Context state.
+// Get the context state.
 const contextState = watchdog.state;
 
 // An event fired when the context watchdog catches the context-related error.

--- a/docs/features/watchdog.md
+++ b/docs/features/watchdog.md
@@ -254,8 +254,6 @@ watchdog.add( {
 
 watchdog.remove( [ 'editor1' ] );
 
-watchdog.add( itemConfig );
-
 // Given item instance.
 const editor1 = watchdog.get( 'editor1' );
 

--- a/docs/features/watchdog.md
+++ b/docs/features/watchdog.md
@@ -300,7 +300,7 @@ watchdog.on( 'error', ( evt, { error } ) => {
 	console.log( 'The context crashed.' );
 } );
 
-// The `restart` event is fired when the context is set back to the `ready` state (after it was in `error` state).
+// The `restart` event is fired when the context is set back to the `ready` state (after it was in `crashed` state).
 // Similarly, this event is not thrown for internal item restarts.
 watchdog.on( 'restart', () => {
 	console.log( 'The context has been restarted.' );
@@ -311,7 +311,7 @@ watchdog.on( 'itemError', ( evt, { error, itemId } ) => {
 	console.log( `An error occurred in an item with the '${ itemId }' id.` );
 } );
 
-// The `itemRestart` event is fired when an item is set back to the `ready` state (after it was in `error` state).
+// The `itemRestart` event is fired when an item is set back to the `ready` state (after it was in `crashed` state).
 watchdog.on( 'itemRestart', ( evt, { itemId } ) => {
 	console.log( 'An item with '${ itemId }' id has been restarted.' );
 } );

--- a/docs/features/watchdog.md
+++ b/docs/features/watchdog.md
@@ -255,13 +255,23 @@ const editor1State = watchdog.getState( 'editor1' );
 // Getting the context state.
 const contextState = watchdog.state;
 
-// Listening to an event fired when the context watchdog catches the context-related error.
+// The `error` event is fired when the context watchdog catches the context-related error.
 // Note that the item errors are not re-fired in the `ContextWatchdog#error`.
-watchdog.on( 'error', () => {} );
+watchdog.on( 'error', ( evt, { error } ) => {} );
 
-// Listening to an event fired when the context is set back to the `ready` state (after it was in `error` state).
+// The `restarted` event is fired when the context is set back to the `ready` state (after it was in `error` state).
 // Similarly, this event is not thrown for internal item restarts.
 watchdog.on( 'restart', () => {} );
+
+// The `itemError` event is fired when an error occurred in one of the added items
+watchdog.on( 'itemError', ( evt, { error, itemId } ) => {
+	console.log( `An error occurred in the item with the '${ itemId }' id.` );
+} );
+
+// The `itemRestarted` event is fired when the item is set back to the `ready` state (after it was in `error` state).
+watchdog.on( 'itemRestart', ( evt, { itemId } ) => {
+	console.log( 'The item with with the '${ itemId }' id has been restarted.' );
+} );
 ```
 
 ## Configuration

--- a/docs/features/watchdog.md
+++ b/docs/features/watchdog.md
@@ -269,12 +269,12 @@ watchdog.on( 'restart', () => {
 
 // The `itemError` event is fired when an error occurred in one of the added items
 watchdog.on( 'itemError', ( evt, { error, itemId } ) => {
-	console.log( `An error occurred in the item with the '${ itemId }' id.` );
+	console.log( `An error occurred in an item with the '${ itemId }' id.` );
 } );
 
 // The `itemRestarted` event is fired when the item is set back to the `ready` state (after it was in `error` state).
 watchdog.on( 'itemRestart', ( evt, { itemId } ) => {
-	console.log( 'The item with with the '${ itemId }' id has been restarted.' );
+	console.log( 'An item with with the '${ itemId }' id has been restarted.' );
 } );
 ```
 

--- a/docs/features/watchdog.md
+++ b/docs/features/watchdog.md
@@ -14,8 +14,8 @@ The {@link module:watchdog/watchdog~Watchdog} utility allows you to do exactly t
 It should be noticed that the most "dangerous" places in the API - like `editor.model.change()`, `editor.editing.view.change()`, emitters - are covered with checks and `try-catch` blocks that allow detecting unknown errors and restart editor when they occur.
 
 Currently there are two available watchdogs, which can be used depending on your needs:
-* [editor watchdog](#editor-watchdog) - it fills the most basic scenario when only one editor is created
-* [context watchdog](#context-watchdog) - it
+* [editor watchdog](#editor-watchdog) - that fills the most basic scenario when only one editor is created,
+* [context watchdog](#context-watchdog) - that keeps an advanced structure of connected editors via te context feature running
 
 ## Usage
 
@@ -230,7 +230,7 @@ watchdog.setDestructor( async context => {
 // Initialize the context watchdog with the context configuration.
 await watchdog.create( contextConfig );
 
-// Add editor configuration.
+// Add editor configuration (or an array of editor configurations).
 await watchdog.add( {
 	id: 'editor1',
 	type: 'editor',

--- a/docs/features/watchdog.md
+++ b/docs/features/watchdog.md
@@ -200,7 +200,8 @@ await watchdog.remove( 'editor2' );
 ```
 
 <info-box>
-	Note that the above examples does not use promises returning by the context watchdog methods while these methods are asynchronous. You should not depend on these promises because they are resolved only once while your component might be restarted multiple times internally causing watchdog to unmount the editor and to mount again. Read further below for more information about events and watchdog states.
+	Examples presents the "synchronous way" of the integration with the context watchdog feature, however it's not needed to wait for the promises returned by the `create()`, `add()` and `remove()` methods. There might be a need
+	to create and destroy editors dynamically with shared context and that's can be easily achieved as all promises operating on the internal API will be chained.
 </info-box>
 
 #### Context watchdog API
@@ -277,7 +278,9 @@ const editorWatchdog = new EditorWatchdog( ClassicEditor, {
 } )
 ```
 
-Note that the context watchdog passes this configuration to the added editors.
+<info-box>
+	Note that the context watchdog passes this configuration to the added editors.
+</info-box>
 
 ## Limitations
 

--- a/docs/features/watchdog.md
+++ b/docs/features/watchdog.md
@@ -230,11 +230,6 @@ await watchdog.remove( 'editor1' );
 await watchdog.remove( 'editor2' );
 ```
 
-<info-box>
-	Examples presents the "synchronous way" of the integration with the context watchdog feature, however it's not needed to wait for the promises returned by the `create()`, `add()` and `remove()` methods. There might be a need
-	to create and destroy items dynamically with shared context and that can be easily achieved as all promises operating on the internal API will be chained.
-</info-box>
-
 #### Context watchdog API
 
 The context watchdog feature provides the following API:

--- a/docs/features/watchdog.md
+++ b/docs/features/watchdog.md
@@ -167,7 +167,7 @@ await watchdog.create( {
 	    // ...
 	],
 	// ...
-} )
+} );
 
 // Add editor instances.
 // You mat also use multiple `ContextWatchdog#add()` calls, each adding a single editor.
@@ -313,7 +313,7 @@ watchdog.on( 'itemError', ( evt, { error, itemId } ) => {
 
 // The `itemRestart` event is fired when an item is set back to the `ready` state (after it was in `error` state).
 watchdog.on( 'itemRestart', ( evt, { itemId } ) => {
-	console.log( 'An item with with the '${ itemId }' id has been restarted.' );
+	console.log( 'An item with '${ itemId }' id has been restarted.' );
 } );
 ```
 

--- a/docs/features/watchdog.md
+++ b/docs/features/watchdog.md
@@ -14,8 +14,8 @@ The {@link module:watchdog/watchdog~Watchdog} utility allows you to do exactly t
 It should be noticed that the most "dangerous" places in the API - like `editor.model.change()`, `editor.editing.view.change()`, emitters - are covered with checks and `try-catch` blocks that allow detecting unknown errors and restart editor when they occur.
 
 Currently there are two available watchdogs, which can be used depending on your needs:
-* [Editor Watchdog](#editor-watchdog)
-* [Context Watchdog](#context-watchdog)
+* [editor watchdog](#editor-watchdog) - it fills the most basic scenario when only one editor is created
+* [context watchdog](#context-watchdog) - it
 
 ## Usage
 
@@ -93,7 +93,7 @@ watchdog.create( elementOrData, editorConfig );
 	The default (not overridden) editor destructor is the `editor => editor.destroy()` function.
 </info-box>
 
-#### API
+#### Editor watchdog API
 
 Other useful {@link module:watchdog/editorwatchdog~EditorWatchdog methods, properties and events}:
 
@@ -170,10 +170,14 @@ import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
 import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
 import Context from '@ckeditor/ckeditor5-core/src/context';
 
-// Create a watchdog for the context
-const watchdog = ContextWatchdog.for( Context );
+// Create a watchdog for the context and pass the context configuration:
+const watchdog = ContextWatchdog.for( Context, {
+	plugins: [],
 
-// Add editor instances.
+	// Rest of the configuration.
+} );
+
+// Add editor instances:
 watchdog.add( {
 	editor1: {
 		type: 'editor',
@@ -195,6 +199,19 @@ watchdog.add( {
 	},
 } );
 ```
+
+The Watchdog will keep the context and editor (and other types of items in the future) instances running
+that are added via the {@link module:watchdog/contextwatchdog~ContextWatchdog#add `ContextWatchdog#add` method}. This method can be called multiple times during the `ContextWatchdog` lifetime.
+
+To destroy one of the editor instances use the {@link module:watchdog/contextwatchdog~ContextWatchdog#remove `ContextWatchdog#remove` method}. This method can be called multiple times during the `ContextWatchdog` lifetime as well.
+
+```js
+watchdog.remove( [ 'editor1' ] );
+```
+
+<info-box>
+	Note that the above examples does not use promises returning by the context watchdog methods while these methods are asynchronous. You should not depend on these promises because they are resolved only once while your component might be restarted multiple times internally causing watchdog to unmount the editor and to mount again. Read further below for more information about events and watchdog states.
+</info-box>
 
 TODO
 

--- a/docs/features/watchdog.md
+++ b/docs/features/watchdog.md
@@ -240,7 +240,7 @@ const watchdog = new ContextWatchdog( Context, watchdogConfig );
 
 // Setting a custom creator for the context.
 watchdog.setCreator( async config => {
-	const context = await Context.create( config ) );
+	const context = await Context.create( config );
 
 	// Do something when the context is initialized.
 

--- a/docs/features/watchdog.md
+++ b/docs/features/watchdog.md
@@ -330,7 +330,7 @@ const editorWatchdog = new EditorWatchdog( ClassicEditor, {
 	minimumNonErrorTimePeriod: 2000,
 	crashNumberLimit: 4,
 	saveInterval: 1000
-} )
+} );
 ```
 
 <info-box>

--- a/docs/features/watchdog.md
+++ b/docs/features/watchdog.md
@@ -133,7 +133,7 @@ watchdog.crashes.forEach( crashInfo => console.log( crashInfo ) );
 ### Context watchdog
 
 <info-box>
-	Note: the ContextWatchdog can be used only with an {@link builds/guides/integration/advanced-setup#scenario-2-building-from-source editor built from source}.
+	Note: the context watchdog can be used only with an {@link builds/guides/integration/advanced-setup#scenario-2-building-from-source editor built from source}.
 </info-box>
 
 Install the [`@ckeditor/ckeditor5-watchdog`](https://www.npmjs.com/package/@ckeditor/ckeditor5-watchdog) package:
@@ -205,7 +205,7 @@ await watchdog.remove( 'editor2' );
 
 #### Context watchdog API
 
-The ContextWatchdog feature provides the following API:
+The context watchdog feature provides the following API:
 
 ```js
 // Create watchdog that will use the `Context` class and given configuration.

--- a/docs/features/watchdog.md
+++ b/docs/features/watchdog.md
@@ -184,7 +184,7 @@ watchdog.add( {
 } );
 ```
 
-The Watchdog will keep the context and editor (and other types of items in the future) instances running
+The Watchdog will keep the context and editor instances running
 that are added via the {@link module:watchdog/contextwatchdog~ContextWatchdog#add `ContextWatchdog#add` method}. This method can be called multiple times during the `ContextWatchdog` lifetime.
 
 To destroy one of the editor instances use the {@link module:watchdog/contextwatchdog~ContextWatchdog#remove `ContextWatchdog#remove` method}. This method can be called multiple times during the `ContextWatchdog` lifetime as well.
@@ -202,7 +202,7 @@ watchdog.remove( [ 'editor1' ] );
 The ContextWatchdog feature provides the following API:
 
 ```js
-// A simple initialization way with default Context creation and destruction functions:
+// A simple initialization with default Context creation and destruction functions:
 const watchdog = ContextWatchdog.for( Context, contextConfig, watchdogConfig )
 
 // An advanced initialization where custom creation and destruction functions can be passed:
@@ -251,7 +251,7 @@ const contextState = watchdog.state;
 // Note that the editor errors are not re-fired in the `ContextWatchdog#error`.
 watchdog.on( 'error', () => {} );
 
-// An event fired when the context is back to the `ready` state.
+// An event fired when the context is set back to the `ready` state (after it was in `error` state).
 // Similarly, this event is not thrown for internal editor instances.
 watchdog.on( 'restart', () => {} );
 ```
@@ -276,4 +276,4 @@ Note that the ContextWatchdog spreads its configuration to the added items.
 
 ## Limitations
 
-The watchdog does not handle errors thrown during the editor or context initialization (by e.g. `Editor.create()`) and editor destruction (e.g. `Editor#destroy()`). Errors thrown at these stages mean that there is a serious problem in the code integrating the editor with your application and such problem cannot be easily fixed by restarting the editor.
+The watchdog does not handle errors thrown during the editor or context initialization (by e.g. `Editor.create()`) and editor destruction (e.g. `Editor#destroy()`). Errors thrown at these stages mean that there is a problem in the code integrating the editor with your application and such a problem cannot be fixed by restarting the editor.

--- a/docs/features/watchdog.md
+++ b/docs/features/watchdog.md
@@ -13,7 +13,7 @@ The {@link module:watchdog/watchdog~Watchdog} utility allows you to do exactly t
 
 It should be noticed that the most "dangerous" places in the API - like `editor.model.change()`, `editor.editing.view.change()`, emitters - are covered with checks and `try-catch` blocks that allow detecting unknown errors and restart editor when they occur.
 
-Currently there are two available watchdogs, which can be used depending on your needs:
+There are two available watchdogs, which can be used depending on your needs:
 * [editor watchdog](#editor-watchdog) - that fills the most basic scenario when only one editor is created,
 * [context watchdog](#context-watchdog) - that keeps an advanced structure of connected editors via te context feature running
 

--- a/docs/features/watchdog.md
+++ b/docs/features/watchdog.md
@@ -257,11 +257,15 @@ const contextState = watchdog.state;
 
 // The `error` event is fired when the context watchdog catches the context-related error.
 // Note that the item errors are not re-fired in the `ContextWatchdog#error`.
-watchdog.on( 'error', ( evt, { error } ) => {} );
+watchdog.on( 'error', ( evt, { error } ) => {
+	console.log( 'The context crashed.' );
+} );
 
 // The `restarted` event is fired when the context is set back to the `ready` state (after it was in `error` state).
 // Similarly, this event is not thrown for internal item restarts.
-watchdog.on( 'restart', () => {} );
+watchdog.on( 'restart', () => {
+	console.log( 'The context has been restarted.' );
+} );
 
 // The `itemError` event is fired when an error occurred in one of the added items
 watchdog.on( 'itemError', ( evt, { error, itemId } ) => {

--- a/docs/features/watchdog.md
+++ b/docs/features/watchdog.md
@@ -213,7 +213,63 @@ watchdog.remove( [ 'editor1' ] );
 	Note that the above examples does not use promises returning by the context watchdog methods while these methods are asynchronous. You should not depend on these promises because they are resolved only once while your component might be restarted multiple times internally causing watchdog to unmount the editor and to mount again. Read further below for more information about events and watchdog states.
 </info-box>
 
-TODO
+### Context watchdog API
+
+The ContextWatchdog feature provides the following API:
+
+```js
+// A simple initialization way with default Context creation and destruction functions:
+const watchdog = ContextWatchdog.for( Context, contextConfig, watchdogConfig )
+
+// An advanced initialization where custom creation and destruction functions can be passed:
+const watchdog = new ContextWatchdog( contextConfig, watchdogConfig )
+
+watchdog.setCreator( async config => {
+	const context = await Context.create( config ) );
+
+	// Do something when the context is initialized.
+
+	return context;
+} );
+
+watchdog.setDestructor( async context => {
+	// Do something before destroy.
+
+	await context.destroy();
+} );
+
+watchdog.create();
+
+// Adding, removing and getting item instances:
+watchdog.add( {
+	editor1: {
+		type: 'editor',
+		sourceElementOrData: editorSourceElementOrEditorData
+		config: editorConfig,
+		creator: createEditor,
+		destructor: destroyEditor,
+	},
+	// Possibly more items.
+} );
+
+watchdog.remove( [ 'editor1' ] );
+
+watchdog.add( itemConfig );
+
+// Given item instance.
+const editor1 = watchdog.get( 'editor1' );
+
+// Given item state.
+const editor1State = watchdog.getState( 'editor1' );
+
+// Context state.
+const contextState = watchdog.state;
+
+// Events
+watchdog.on( 'error', () => {} );
+
+watchdog.on( 'restart', () => {} );
+```
 
 ## Limitations
 

--- a/package.json
+++ b/package.json
@@ -10,8 +10,6 @@
   ],
   "dependencies": {
     "@ckeditor/ckeditor5-utils": "^16.0.0",
-    "@types/mocha": "^5.2.7",
-    "@types/sinon": "^7.5.1",
     "lodash-es": "^4.17.10"
   },
   "devDependencies": {
@@ -23,8 +21,8 @@
     "eslint-config-ckeditor5": "^2.0.0",
     "husky": "^2.4.1",
     "lint-staged": "^8.2.1",
-    "stylelint": "^11.1.1",
-    "stylelint-config-ckeditor5": "^1.0.0"
+    "stylelint-config-ckeditor5": "^1.0.0",
+    "stylelint": "^11.1.1"
   },
   "engines": {
     "node": ">=8.0.0",

--- a/src/contextwatchdog.js
+++ b/src/contextwatchdog.js
@@ -106,15 +106,24 @@ export default class ContextWatchdog extends Watchdog {
 	 * 	const editor1 = contextWatchdog.get( 'editor1' );
 	 *
 	 * @param {String} itemName The item name (the key under which the item config was passed to the add() method).
+	 * @returns {*} The item instance.
 	 */
 	get( itemName ) {
-		const watchdog = this._watchdogs.get( itemName );
-
-		if ( !watchdog ) {
-			throw new Error( `Item with the given name was not registered: ${ itemName }.` );
-		}
+		const watchdog = this._getWatchdog( itemName );
 
 		return watchdog._instance;
+	}
+
+	/**
+	 * Gets state of the given item. For the list of available state see {@link #state}.
+	 *
+	 * @param {String} itemName The item name (the key under which the item config was passed to the add() method).
+	 * @returns {'initializing'|'ready'|'crashed'|'crashedPermanently'|'destroyed'} The state of the item.
+	 */
+	getState( itemName ) {
+		const watchdog = this._getWatchdog( itemName );
+
+		return watchdog.state;
 	}
 
 	/**
@@ -312,6 +321,21 @@ export default class ContextWatchdog extends Watchdog {
 					// Context destructor destroys each editor.
 					.then( () => this._destructor( context ) );
 			} );
+	}
+
+	/**
+	 * @protected
+	 * @param {String} itemName
+	 * @returns {module:watchdog/watchdog~Watchdog} Watchdog
+	 */
+	_getWatchdog( itemName ) {
+		const watchdog = this._watchdogs.get( itemName );
+
+		if ( !watchdog ) {
+			throw new Error( `Item with the given name was not registered: ${ itemName }.` );
+		}
+
+		return watchdog;
 	}
 
 	/**

--- a/src/contextwatchdog.js
+++ b/src/contextwatchdog.js
@@ -114,7 +114,7 @@ export default class ContextWatchdog extends Watchdog {
 			throw new Error( `Item with the given name was not registered: ${ itemName }.` );
 		}
 
-		return watchdog[ watchdog.constructor.instanceType ];
+		return watchdog._instance;
 	}
 
 	/**

--- a/src/contextwatchdog.js
+++ b/src/contextwatchdog.js
@@ -22,6 +22,8 @@ import getSubNodes from './utils/getsubnodes';
  */
 export default class ContextWatchdog extends Watchdog {
 	/**
+	 * The constructor should not be called directly. Use the {@link module:watchdog/contextwatchdog~ContextWatchdog.for} method instead.
+	 *
 	 * @param {Object} [contextConfig] {@link module:core/context~Context} configuration.
 	 * @param {module:watchdog/watchdog~WatchdogConfig} [watchdogConfig] The watchdog plugin configuration.
 	 */
@@ -110,6 +112,18 @@ export default class ContextWatchdog extends Watchdog {
 	/**
 	 * Adds items to the watchdog. Internally watchdogs will be created for these items and they will be available later using
 	 * the {@link #getWatchdog} method.
+	 *
+	 * 	watchdog.add( {
+	 *		editor1: {
+	 *			type: 'editor',
+	 *			sourceElementOrData: document.querySelector( '#editor' ),
+	 *			config: {
+	 *				plugins: [ Essentials, Paragraph, Bold, Italic ],
+	 *				toolbar: [ 'bold', 'italic', 'alignment' ]
+	 *			},
+	 *			creator: ( element, config ) => ClassicEditor.create( element, config )
+	 *		}
+	 * 	}
 	 *
 	 * // @param {Array.<Object.<String,module:watchdog/contextwatchdog~WatchdogItemConfiguration>>} itemConfigurations
 	 * @param {Array.<Object>} itemConfigurations
@@ -300,6 +314,14 @@ export default class ContextWatchdog extends Watchdog {
 	}
 
 	/**
+	 * Creates context watchdog for the given Context constructor, context configuration and watchdog configuration.
+	 *
+	 * 	const contextWatchdog = ContextWatchdog.for( Context, {
+	 * 		plugins: []
+	 * 	} );
+	 *
+	 * 	contextWatchdog.add( watchdogItem );
+	 *
 	 * @param {module:core/context~Context} Context
 	 * @param {Object} [contextConfig]
 	 * @param {module:watchdog/watchdog~WatchdogConfig} [watchdogConfig]
@@ -413,7 +435,7 @@ class ActionQueue {
 }
 
 /**
- * The WatchdogItemConfiguration interface
+ * The WatchdogItemConfiguration interface.
  *
  * @typedef {module:watchdog/contextwatchdog~EditorWatchdogConfiguration} module:watchdog/contextwatchdog~WatchdogItemConfiguration
  */
@@ -422,6 +444,8 @@ class ActionQueue {
  * The EditorWatchdogConfiguration interface specifies how editors should be created and destroyed.
  *
  * @typedef {Object} module:watchdog/contextwatchdog~EditorWatchdogConfiguration
+ *
+ * @property {'editor'} type A type of the item to create. In this case it should be set to the `editor`.
  *
  * @property {Function} creator A function that needs to be called to initialize the editor.
  *

--- a/src/contextwatchdog.js
+++ b/src/contextwatchdog.js
@@ -135,7 +135,7 @@ export default class ContextWatchdog extends Watchdog {
 	 * 	const editor1 = contextWatchdog.get( 'editor1' );
 	 *
 	 * @param {String} itemId The item id.
-	 * @returns {*} The item instance or `undefined`.
+	 * @returns {*} The item instance or `undefined` if an item with given id has not been found.
 	 */
 	get( itemId ) {
 		const watchdog = this._getWatchdog( itemId );

--- a/src/contextwatchdog.js
+++ b/src/contextwatchdog.js
@@ -441,6 +441,36 @@ export default class ContextWatchdog extends Watchdog {
 
 		return areConnectedThroughProperties( this._context, error.context );
 	}
+
+	/**
+	 * Fired after the watchdog restarts context and added items because of the crash.
+	 *
+	 * 	watchdog.on( 'restart', () => {
+	 * 		console.log( 'The context has been restarted.' );
+	 * 	} );
+	 *
+	 * @event restart
+	 */
+
+	/**
+	 * Fired when a new error occurred in one of the added items.
+	 *
+	 * 	watchdog.on( 'itemError', ( evt, { error, itemId, causesRestart } ) => {
+	 *		console.log( `An error occurred in the item with the '${ itemId }' id.` );
+	 * 	} );
+	 *
+	 * @event itemError
+	 */
+
+	/**
+	 * Fired after an item has been restarted.
+	 *
+	 * 	watchdog.on( 'itemRestart', ( evt, { itemId } ) => {
+	 *		console.log( 'The item with with the '${ itemId }' id has been restarted.' );
+	 * 	} );
+	 *
+	 * @event itemRestart
+	 */
 }
 
 // An action queue that allows queuing async functions.

--- a/src/contextwatchdog.js
+++ b/src/contextwatchdog.js
@@ -19,6 +19,8 @@ import getSubNodes from './utils/getsubnodes';
  *
  * See the {@glink features/watchdog Watchdog feature guide} to learn the rationale behind it and
  * how to use it.
+ *
+ * @extends {module:watchdog/watchdog~Watchdog}
  */
 export default class ContextWatchdog extends Watchdog {
 	/**
@@ -481,7 +483,7 @@ class ActionQueue {
  *
  * @typedef {Object} module:watchdog/contextwatchdog~EditorWatchdogConfiguration
  *
- * @property {string} id A unique item identificator.
+ * @property {String} id A unique item identificator.
  *
  * @property {'editor'} type Type of the item to create. At the moment, only `'editor'` is supported.
  *

--- a/src/contextwatchdog.js
+++ b/src/contextwatchdog.js
@@ -25,7 +25,7 @@ export default class ContextWatchdog extends Watchdog {
 	 * The constructor should not be called directly. Use the {@link module:watchdog/contextwatchdog~ContextWatchdog.for} method instead.
 	 *
 	 * @param {Object} [contextConfig] {@link module:core/context~Context} configuration.
-	 * @param {module:watchdog/watchdog~WatchdogConfig} [watchdogConfig] The watchdog plugin configuration.
+	 * @param {module:watchdog/watchdog~WatchdogConfig} [watchdogConfig] The watchdog configuration.
 	 */
 	constructor( contextConfig = {}, watchdogConfig = {} ) {
 		super( watchdogConfig );
@@ -37,6 +37,14 @@ export default class ContextWatchdog extends Watchdog {
 		 * @type {Map.<string,module:watchdog/watchdog~EditorWatchdog>}
 		 */
 		this._watchdogs = new Map();
+
+		/**
+		 * The watchdog configuration.
+		 *
+		 * @private
+		 * @type {module:watchdog/watchdog~WatchdogConfig}
+		 */
+		this._watchdogConfig = watchdogConfig;
 
 		/**
 		 * The current context instance.
@@ -168,8 +176,7 @@ export default class ContextWatchdog extends Watchdog {
 				}
 
 				if ( item.type === 'editor' ) {
-					// TODO - await EditorWatchdog.createFrom( item, context ) ?
-					watchdog = new EditorWatchdog();
+					watchdog = new EditorWatchdog( this._watchdogConfig );
 					watchdog.setCreator( item.creator );
 					watchdog._setExcludedProperties( this._contextProps );
 
@@ -248,6 +255,8 @@ export default class ContextWatchdog extends Watchdog {
 	destroy() {
 		return this._actionQueue.enqueue( () => {
 			this.state = 'destroyed';
+
+			super.destroy();
 
 			return this._destroy();
 		} );

--- a/src/contextwatchdog.js
+++ b/src/contextwatchdog.js
@@ -414,7 +414,7 @@ export default class ContextWatchdog extends Watchdog {
 	}
 
 	/**
-	 * Checks whether the error comes from the Context and not from the item instances.
+	 * Checks whether the error comes from the `Context` instance and not from the item instances.
 	 *
 	 * @protected
 	 * @param {Error} error
@@ -427,9 +427,7 @@ export default class ContextWatchdog extends Watchdog {
 			}
 		}
 
-		// Return true only if the error comes directly from the context.
-		// Ignore cases when the error comes from editors.
-		return areConnectedThroughProperties( this._contextProps, error.context );
+		return areConnectedThroughProperties( this._context, error.context );
 	}
 }
 

--- a/src/contextwatchdog.js
+++ b/src/contextwatchdog.js
@@ -213,8 +213,6 @@ export default class ContextWatchdog extends Watchdog {
 	 */
 	remove( itemNames ) {
 		return this._actionQueue.enqueue( () => {
-			console.log( 'remove' );
-
 			return Promise.all( itemNames.map( itemName => {
 				const watchdog = this._getWatchdog( itemName );
 
@@ -269,7 +267,6 @@ export default class ContextWatchdog extends Watchdog {
 	 */
 	_restart() {
 		return this._actionQueue.enqueue( () => {
-			console.log( 'restarting' );
 			this.state = 'initializing';
 
 			return this._destroy()
@@ -277,8 +274,7 @@ export default class ContextWatchdog extends Watchdog {
 					console.error( 'An error happened during destructing.', err );
 				} )
 				.then( () => this._create() )
-				.then( () => this.fire( 'restart' ) )
-				.then( () => console.log( 'restarted' ) );
+				.then( () => this.fire( 'restart' ) );
 		} );
 	}
 

--- a/src/contextwatchdog.js
+++ b/src/contextwatchdog.js
@@ -105,8 +105,8 @@ export default class ContextWatchdog extends Watchdog {
 	}
 
 	/**
-	 * The context instance. Keep in mind that this property might be changed when the ContextWatchdog restarts,
-	 * so do not keep this instance internally. Always operate on the `contextWatchdog.context` property.
+	 * The context instance. Keep in mind that this property might be changed when the `ContextWatchdog` restarts,
+	 * so do not keep this instance internally. Always operate on the `ContextWatchdog#context` property.
 	 *
 	 * @type {module:core/context~Context|null}
 	 */

--- a/src/contextwatchdog.js
+++ b/src/contextwatchdog.js
@@ -22,7 +22,8 @@ import getSubNodes from './utils/getsubnodes';
  */
 export default class ContextWatchdog extends Watchdog {
 	/**
-	 * The constructor should not be called directly. Use the {@link module:watchdog/contextwatchdog~ContextWatchdog.for} method instead.
+	 * The ContextWatchdog constructor. See {@glink features/watchdog Watchdog feature guide} to learn how to use it,
+	 * as using the constructor directly requires further steps to initialize the `ContextWatchdog`.
 	 *
 	 * @param {Object} [contextConfig] {@link module:core/context~Context} configuration.
 	 * @param {module:watchdog/watchdog~WatchdogConfig} [watchdogConfig] The watchdog configuration.
@@ -333,6 +334,8 @@ export default class ContextWatchdog extends Watchdog {
 	}
 
 	/**
+	 * Returns watchdog for the given item name.
+	 *
 	 * @protected
 	 * @param {String} itemName
 	 * @returns {module:watchdog/watchdog~Watchdog} Watchdog

--- a/src/contextwatchdog.js
+++ b/src/contextwatchdog.js
@@ -268,15 +268,6 @@ export default class ContextWatchdog extends Watchdog {
 	}
 
 	/**
-	 * Waits for all previous actions.
-	 *
-	 * @returns {Promise}
-	 */
-	waitForReady() {
-		return this._actionQueue.enqueue( () => { } );
-	}
-
-	/**
 	 * Destroys the `ContextWatchdog` and all added items.
 	 * Once the `ContextWatchdog` is destroyed new items can not be added.
 	 *

--- a/src/contextwatchdog.js
+++ b/src/contextwatchdog.js
@@ -110,10 +110,10 @@ export default class ContextWatchdog extends Watchdog {
 		 * It expects a function that should return a promise (or `undefined`).
 		 *
 		 *		watchdog.setCreator( config => Context.create( config ) );
-		*
-		* @method #setCreator
-		* @param {Function} creator
-		*/
+		 *
+		 * @method #setCreator
+		 * @param {Function} creator
+		 */
 
 		/**
 		 * Sets the function that is responsible for the context destruction.
@@ -122,17 +122,17 @@ export default class ContextWatchdog extends Watchdog {
 		 *
 		 *		watchdog.setDestructor( context => {
 		 *			// Do something before the context is destroyed.
-		*
-		*			return context
-		*				.destroy()
-		*				.then( () => {
-		*					// Do something after the context is destroyed.
-		*				} );
-		*		} );
-		*
-		* @method #setDestructor
-		* @param {Function} destructor
-		*/
+		 *
+		 *			return context
+		 *				.destroy()
+		 *				.then( () => {
+		 *					// Do something after the context is destroyed.
+		 *				} );
+		 *		} );
+		 *
+		 * @method #setDestructor
+		 * @param {Function} destructor
+		 */
 	}
 
 	/**
@@ -165,7 +165,7 @@ export default class ContextWatchdog extends Watchdog {
 	}
 
 	/**
-     * Returns the item instance with the given `itemId`.
+	 * Returns the item instance with the given `itemId`.
 	 *
 	 * 	const editor1 = watchdog.get( 'editor1' );
 	 *
@@ -483,7 +483,7 @@ class ActionQueue {
 		this._onEmptyCallbacks = [];
 	}
 
-	// A method used to register callbacks that will be run when the queue becomes empty.
+	// Used to register callbacks that will be run when the queue becomes empty.
 	//
 	// @param {Function} onEmptyCallback A callback that will be run whenever the queue becomes empty.
 	onEmpty( onEmptyCallback ) {
@@ -513,13 +513,13 @@ class ActionQueue {
 }
 
 /**
- * The WatchdogItemConfiguration interface.
+ * The `WatchdogItemConfiguration` interface.
  *
  * @typedef {module:watchdog/contextwatchdog~EditorWatchdogConfiguration} module:watchdog/contextwatchdog~WatchdogItemConfiguration
  */
 
 /**
- * The EditorWatchdogConfiguration interface specifies how editors should be created and destroyed.
+ * The `EditorWatchdogConfiguration` interface specifies how editors should be created and destroyed.
  *
  * @typedef {Object} module:watchdog/contextwatchdog~EditorWatchdogConfiguration
  *

--- a/src/contextwatchdog.js
+++ b/src/contextwatchdog.js
@@ -24,11 +24,11 @@ export default class ContextWatchdog extends Watchdog {
 	/**
 	 * The `ContextWatchdog` class constructor.
 	 *
-	 * 	const contextWatchdog = new ContextWatchdog( Context );
+	 * 	const watchdog = new ContextWatchdog( Context );
 	 *
-	 * 	await contextWatchdog.create( contextConfiguration );
+	 * 	await watchdog.create( contextConfiguration );
 	 *
-	 * 	await contextWatchdog.add( watchdogItem );
+	 * 	await watchdog.add( item );
 	 *
 	 * See {@glink features/watchdog the watchdog feature guide} to learn more how to use this feature.
 	 *
@@ -147,6 +147,10 @@ export default class ContextWatchdog extends Watchdog {
 	 * Initializes the context watchdog. Once it's created the watchdog takes care about
 	 * recreating the context and provided items and starts the error handling mechanism.
 	 *
+	 * 	await watchdog.create( {
+	 * 		plugins: []
+	 * 	} );
+	 *
 	 * @param {Object} [contextConfig] Context configuration. See {@link module:core/context~Context}.
 	 * @returns {Promise}
 	 */
@@ -161,7 +165,7 @@ export default class ContextWatchdog extends Watchdog {
 	/**
      * Returns the item instance with the given `itemId`.
 	 *
-	 * 	const editor1 = contextWatchdog.get( 'editor1' );
+	 * 	const editor1 = watchdog.get( 'editor1' );
 	 *
 	 * @param {String} itemId The item id.
 	 * @returns {*} The item instance or `undefined` if an item with given id has not been found.
@@ -174,6 +178,8 @@ export default class ContextWatchdog extends Watchdog {
 
 	/**
 	 * Gets state of the given item. For the list of available states see {@link #state}.
+	 *
+	 * 	const editor1State = watchdog.getState( 'editor1' );
 	 *
 	 * @param {String} itemId Item id.
 	 * @returns {'initializing'|'ready'|'crashed'|'crashedPermanently'|'destroyed'} The state of the item.
@@ -277,6 +283,12 @@ export default class ContextWatchdog extends Watchdog {
 	/**
 	 * Removes and destroys item(s) with given id(s).
 	 *
+	 * 	await watchdog.remove( 'editor1' );
+	 *
+	 * Or
+	 *
+	 * 	await watchdog.remove( [ 'editor1', 'editor2' ] );
+	 *
 	 * @param {Array.<String>|String} itemIdOrItemIds Item id or an array of item ids.
 	 * @returns {Promise}
 	 */
@@ -299,6 +311,8 @@ export default class ContextWatchdog extends Watchdog {
 	/**
 	 * Destroys the `ContextWatchdog` and all added items.
 	 * Once the `ContextWatchdog` is destroyed new items can not be added.
+	 *
+	 * 	await watchdog.destroy();
 	 *
 	 * @returns {Promise}
 	 */

--- a/src/contextwatchdog.js
+++ b/src/contextwatchdog.js
@@ -82,7 +82,7 @@ export default class ContextWatchdog extends Watchdog {
 		this._destructor = context => context.destroy();
 
 		this._actionQueue.onEmpty( () => {
-			if ( this.state !== 'destroyed' ) {
+			if ( this.state === 'initializing' ) {
 				this.state = 'ready';
 			}
 		} );

--- a/src/contextwatchdog.js
+++ b/src/contextwatchdog.js
@@ -15,7 +15,7 @@ import areConnectedThroughProperties from './utils/areconnectedthroughproperties
 import getSubNodes from './utils/getsubnodes';
 
 /**
- * The Context Watchdog class.
+ * A watchdog for the {@link module:core/context~Context} class.
  *
  * See the {@glink features/watchdog Watchdog feature guide} to learn the rationale behind it and
  * how to use it.

--- a/src/contextwatchdog.js
+++ b/src/contextwatchdog.js
@@ -413,15 +413,6 @@ class ActionQueue {
 	}
 
 	/**
-	 * Clears all queued actions (e.g. in case of an error).
-	 *
-	 * @protected
-	 */
-	_clear() {
-		this._queuedActions = [];
-	}
-
-	/**
 	 * It handles queued actions one by one.
 	 *
 	 * @private

--- a/src/contextwatchdog.js
+++ b/src/contextwatchdog.js
@@ -324,7 +324,7 @@ export default class ContextWatchdog extends Watchdog {
 
 			return this._destroy()
 				.catch( err => {
-					console.error( 'An error happened during destructing.', err );
+					console.error( 'An error happened during destroying the context or items.', err );
 				} )
 				.then( () => this._create() )
 				.then( () => this.fire( 'restart' ) );

--- a/src/contextwatchdog.js
+++ b/src/contextwatchdog.js
@@ -194,7 +194,7 @@ export default class ContextWatchdog extends Watchdog {
 	}
 
 	/**
-	 * Adds items to the watchdog. Once created, instances of these items will be available using the {@link #get} method.
+	 * Adds items to the watchdog. Once created, instances of these items will be available using the {@link #getItem} method.
 	 *
 	 * Items can be passed together as an array of objects:
 	 *

--- a/src/contextwatchdog.js
+++ b/src/contextwatchdog.js
@@ -156,7 +156,7 @@ export default class ContextWatchdog extends Watchdog {
 	}
 
 	/**
-	 * Adds items to the watchdog. Instances of these items once created will be available using the {@link #get} method.
+	 * Adds items to the watchdog. Once created, instances of these items will be available using the {@link #get} method.
 	 *
 	 * Items can be passed together as an array of objects:
 	 *
@@ -246,7 +246,7 @@ export default class ContextWatchdog extends Watchdog {
 	}
 
 	/**
-	 * Removes and destroys item(s) by its / their id(s).
+	 * Removes and destroys item(s) with given id(s).
 	 *
 	 * @param {Array.<String>|String} itemIdOrItemIds Item id or an array of item ids.
 	 * @returns {Promise}
@@ -329,7 +329,7 @@ export default class ContextWatchdog extends Watchdog {
 	}
 
 	/**
-	 * Destroys the Context and all added items.
+	 * Destroys the `Context` instance and all added items.
 	 *
 	 * @private
 	 * @returns {Promise}
@@ -371,7 +371,7 @@ export default class ContextWatchdog extends Watchdog {
 	}
 
 	/**
-	 * Checks whether the error comes from the Context and not from Editor or ContextItem instances.
+	 * Checks whether the error comes from the Context and not from the item instances.
 	 *
 	 * @protected
 	 * @param {Error} error

--- a/src/contextwatchdog.js
+++ b/src/contextwatchdog.js
@@ -167,12 +167,12 @@ export default class ContextWatchdog extends Watchdog {
 	/**
 	 * Returns the item instance with the given `itemId`.
 	 *
-	 * 	const editor1 = watchdog.get( 'editor1' );
+	 * 	const editor1 = watchdog.getItem( 'editor1' );
 	 *
 	 * @param {String} itemId The item id.
 	 * @returns {*} The item instance or `undefined` if an item with given id has not been found.
 	 */
-	get( itemId ) {
+	getItem( itemId ) {
 		const watchdog = this._getWatchdog( itemId );
 
 		return watchdog._item;
@@ -181,12 +181,12 @@ export default class ContextWatchdog extends Watchdog {
 	/**
 	 * Gets state of the given item. For the list of available states see {@link #state}.
 	 *
-	 * 	const editor1State = watchdog.getState( 'editor1' );
+	 * 	const editor1State = watchdog.getItemState( 'editor1' );
 	 *
 	 * @param {String} itemId Item id.
 	 * @returns {'initializing'|'ready'|'crashed'|'crashedPermanently'|'destroyed'} The state of the item.
 	 */
-	getState( itemId ) {
+	getItemState( itemId ) {
 		const watchdog = this._getWatchdog( itemId );
 
 		return watchdog.state;
@@ -223,7 +223,7 @@ export default class ContextWatchdog extends Watchdog {
 	 *
 	 * And then the instance can be retrieved using the {@link #get} method:
 	 *
-	 * 	const editor1 = watchdog.get( 'editor1' );
+	 * 	const editor1 = watchdog.getItem( 'editor1' );
 	 *
 	 * Note that this method can be called multiple times, but for performance reasons it's better
 	 * to pass all items together.

--- a/src/contextwatchdog.js
+++ b/src/contextwatchdog.js
@@ -102,6 +102,35 @@ export default class ContextWatchdog extends Watchdog {
 				this.state = 'ready';
 			}
 		} );
+
+		/**
+		 * Sets the function that is responsible for the context creation.
+		 * It expects a function that should return a promise (or `undefined`).
+		 *
+		 *		watchdog.setCreator( config => Context.create( config ) );
+		*
+		* @method #setCreator
+		* @param {Function} creator
+		*/
+
+		/**
+		 * Sets the function that is responsible for the context destruction.
+		 * Overrides the default destruction function, which destroys only the context instance.
+		 * It expects a function that should return a promise (or `undefined`).
+		 *
+		 *		watchdog.setDestructor( context => {
+		 *			// Do something before the context is destroyed.
+		*
+		*			return context
+		*				.destroy()
+		*				.then( () => {
+		*					// Do something after the context is destroyed.
+		*				} );
+		*		} );
+		*
+		* @method #setDestructor
+		* @param {Function} destructor
+		*/
 	}
 
 	/**
@@ -444,9 +473,11 @@ class ActionQueue {
  *
  * @property {'editor'} type Type of the item to create. At the moment, only `'editor'` is supported.
  *
- * @property {Function} creator A function that initializes the editor. E.g. `( el, config ) => ClassicEditor.create( el, config )`.
+ * @property {Function} creator A function that initializes the item (the editor). The function takes editor initialization arguments
+ * and should return a promise. E.g. `( el, config ) => ClassicEditor.create( el, config )`.
  *
- * @property {Function} [destructor] A function that destroys the editor. E.g. `editor => editor.destroy()`
+ * @property {Function} [destructor] A function that destroys the item instance (the editor). The function
+ * takes an item and should return a promise. E.g. `editor => editor.destroy()`
  *
  * @property {String|HTMLElement} sourceElementOrData The source element or data which will be passed
  * as the first argument to the `Editor.create()` method.

--- a/src/contextwatchdog.js
+++ b/src/contextwatchdog.js
@@ -108,7 +108,7 @@ export default class ContextWatchdog extends Watchdog {
 	}
 
 	/**
-	 * Returns the instance created from the item configuration by its name. It's type depends on the item type
+     * Returns the item with the given `itemName` that was created by this watchdog.
 	 * the instance can be retrieved from the watchdog. Note that this might return `undefined` if the item is not created
 	 * yet.
 	 *
@@ -244,7 +244,7 @@ export default class ContextWatchdog extends Watchdog {
 	}
 
 	/**
-	 * Destroys the `ContextWatchdog` and all added items. This method can't be undone.
+	 * Destroys the `ContextWatchdog` and all added items.
 	 * Once the `ContextWatchdog` is destroyed new items can not be added.
 	 *
 	 * @returns {Promise}
@@ -495,11 +495,11 @@ class ActionQueue {
  *
  * @typedef {Object} module:watchdog/contextwatchdog~EditorWatchdogConfiguration
  *
- * @property {'editor'} type A type of the item to create. In this case it should be set to the `editor`.
+ * @property {'editor'} type Type of the item to create. At the moment, only `'editor'` is supported.
  *
- * @property {Function} creator A function that needs to be called to initialize the editor.
+ * @property {Function} creator A function that initializes the editor.
  *
- * @property {Function} [destructor] A function that is responsible for destructing the editor.
+ * @property {Function} [destructor] A function that destroys the editor.
  *
  * @property {String|HTMLElement} sourceElementOrData The source element or data which will be passed
  * as the first argument to the `Editor.create()` method.

--- a/src/contextwatchdog.js
+++ b/src/contextwatchdog.js
@@ -481,9 +481,9 @@ class ActionQueue {
  *
  * @property {'editor'} type Type of the item to create. At the moment, only `'editor'` is supported.
  *
- * @property {Function} [creator] A function that initializes the editor.
+ * @property {Function} creator A function that initializes the editor. E.g. `( el, config ) => ClassicEditor.create( el, config )`.
  *
- * @property {Function} [destructor] A function that destroys the editor.
+ * @property {Function} [destructor] A function that destroys the editor. E.g. `editor => editor.destroy()`
  *
  * @property {String|HTMLElement} sourceElementOrData The source element or data which will be passed
  * as the first argument to the `Editor.create()` method.

--- a/src/contextwatchdog.js
+++ b/src/contextwatchdog.js
@@ -222,7 +222,7 @@ export default class ContextWatchdog extends Watchdog {
 	 *		creator: ( element, config ) => ClassicEditor.create( element, config )
 	 *	] );
 	 *
-	 * And then the instance can be retrieved using the {@link #get} method:
+	 * And then the instance can be retrieved using the {@link #getItem} method:
 	 *
 	 * 	const editor1 = watchdog.getItem( 'editor1' );
 	 *

--- a/src/contextwatchdog.js
+++ b/src/contextwatchdog.js
@@ -175,7 +175,7 @@ export default class ContextWatchdog extends Watchdog {
 	get( itemId ) {
 		const watchdog = this._getWatchdog( itemId );
 
-		return watchdog._instance;
+		return watchdog._item;
 	}
 
 	/**
@@ -432,9 +432,9 @@ export default class ContextWatchdog extends Watchdog {
 	 * @param {Error} error
 	 * @returns {Boolean}
 	 */
-	_isErrorComingFromThisInstance( error ) {
+	_isErrorComingFromThisItem( error ) {
 		for ( const watchdog of this._watchdogs.values() ) {
-			if ( watchdog._isErrorComingFromThisInstance( error ) ) {
+			if ( watchdog._isErrorComingFromThisItem( error ) ) {
 				return false;
 			}
 		}

--- a/src/contextwatchdog.js
+++ b/src/contextwatchdog.js
@@ -213,14 +213,12 @@ export default class ContextWatchdog extends Watchdog {
 	 */
 	remove( itemNames ) {
 		return this._actionQueue.enqueue( () => {
+			console.log( 'remove' );
+
 			return Promise.all( itemNames.map( itemName => {
-				const watchdog = this._watchdogs.get( itemName );
+				const watchdog = this._getWatchdog( itemName );
 
 				this._watchdogs.delete( itemName );
-
-				if ( !watchdog ) {
-					throw new Error( `There is no watchdog named: '${ itemName }'.` );
-				}
 
 				return watchdog.destroy();
 			} ) );
@@ -271,6 +269,7 @@ export default class ContextWatchdog extends Watchdog {
 	 */
 	_restart() {
 		return this._actionQueue.enqueue( () => {
+			console.log( 'restarting' );
 			this.state = 'initializing';
 
 			return this._destroy()
@@ -278,7 +277,8 @@ export default class ContextWatchdog extends Watchdog {
 					console.error( 'An error happened during destructing.', err );
 				} )
 				.then( () => this._create() )
-				.then( () => this.fire( 'restart' ) );
+				.then( () => this.fire( 'restart' ) )
+				.then( () => console.log( 'restarted' ) );
 		} );
 	}
 

--- a/src/contextwatchdog.js
+++ b/src/contextwatchdog.js
@@ -439,12 +439,14 @@ class ActionQueue {
 		if ( !action ) {
 			this._onEmptyCallbacks.forEach( cb => cb() );
 
-			return res();
+			res();
+
+			return;
 		}
 
 		const resolve = this._resolveCallbacks.get( action );
 
-		Promise.resolve()
+		return Promise.resolve()
 			.then( () => action() )
 			.then( () => {
 				if ( resolve ) {

--- a/src/contextwatchdog.js
+++ b/src/contextwatchdog.js
@@ -456,7 +456,7 @@ export default class ContextWatchdog extends Watchdog {
 	 * Fired when a new error occurred in one of the added items.
 	 *
 	 * 	watchdog.on( 'itemError', ( evt, { error, itemId, causesRestart } ) => {
-	 *		console.log( `An error occurred in the item with the '${ itemId }' id.` );
+	 *		console.log( `An error occurred in an item with the '${ itemId }' id.` );
 	 * 	} );
 	 *
 	 * @event itemError
@@ -466,7 +466,7 @@ export default class ContextWatchdog extends Watchdog {
 	 * Fired after an item has been restarted.
 	 *
 	 * 	watchdog.on( 'itemRestart', ( evt, { itemId } ) => {
-	 *		console.log( 'The item with with the '${ itemId }' id has been restarted.' );
+	 *		console.log( 'An item with with the '${ itemId }' id has been restarted.' );
 	 * 	} );
 	 *
 	 * @event itemRestart

--- a/src/editorwatchdog.js
+++ b/src/editorwatchdog.js
@@ -142,7 +142,7 @@ export default class EditorWatchdog extends Watchdog {
 				return this._destroy();
 			} )
 			.catch( err => {
-				console.error( 'An error happened during the editor destructing.', err );
+				console.error( 'An error happened during the editor destroying.', err );
 			} )
 			.then( () => {
 				if ( typeof this._elementOrData === 'string' ) {

--- a/src/editorwatchdog.js
+++ b/src/editorwatchdog.js
@@ -199,8 +199,9 @@ export default class EditorWatchdog extends Watchdog {
 	}
 
 	/**
-	 * Destroys the current editor instance by using the destructor passed to the {@link #setDestructor `setDestructor()`} method
-	 * and sets state to `destroyed`.
+	 * Destroys the watchdog and the current editor instance. It fires the callback
+	 * registered in {@link #setDestructor `setDestructor()`} and uses it to destroy the editor instance.
+	 * It also sets state to `destroyed`.
 	 *
 	 * @returns {Promise}
 	 */

--- a/src/editorwatchdog.js
+++ b/src/editorwatchdog.js
@@ -22,7 +22,7 @@ import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
  */
 export default class EditorWatchdog extends Watchdog {
 	/**
-	 * @param {module:watchdog/editorwatchdog~EditorWatchdogConfig} [config] The watchdog plugin configuration.
+	 * @param {module:watchdog/watchdog~WatchdogConfig} [config] The watchdog plugin configuration.
 	 */
 	constructor( config = {} ) {
 		super( config );
@@ -338,7 +338,7 @@ export default class EditorWatchdog extends Watchdog {
 	 *		watchdog.create( elementOrData, config );
 	 *
 	 * @param {*} Editor The editor class.
-	 * @param {module:watchdog/editorwatchdog~EditorWatchdogConfig} [watchdogConfig] The watchdog plugin configuration.
+	 * @param {module:watchdog/watchdog~WatchdogConfig} [watchdogConfig] The watchdog plugin configuration.
 	 */
 	static for( Editor, watchdogConfig ) {
 		const watchdog = new this( watchdogConfig );
@@ -354,12 +354,3 @@ export default class EditorWatchdog extends Watchdog {
 	 * @event restart
 	 */
 }
-
-/**
- * The editor watchdog plugin configuration.
- *
- * @typedef {WatchdogConfig} EditorWatchdogConfig
- *
- * @property {Number} [saveInterval=5000] A minimum number of milliseconds between saving editor data internally, (defaults to 5000).
- * Note that for large documents this might have an impact on the editor performance.
- */

--- a/src/editorwatchdog.js
+++ b/src/editorwatchdog.js
@@ -144,13 +144,13 @@ export default class EditorWatchdog extends Watchdog {
 			} )
 			.then( () => {
 				if ( typeof this._elementOrData === 'string' ) {
-					return this.create( this._data, this._config );
+					return this.create( this._data, this._config, this._config.context );
 				} else {
 					const updatedConfig = Object.assign( {}, this._config, {
 						initialData: this._data
 					} );
 
-					return this.create( this._elementOrData, updatedConfig );
+					return this.create( this._elementOrData, updatedConfig, updatedConfig.context );
 				}
 			} )
 			.then( () => {

--- a/src/editorwatchdog.js
+++ b/src/editorwatchdog.js
@@ -143,15 +143,15 @@ export default class EditorWatchdog extends Watchdog {
 				console.error( 'An error happened during the editor destructing.', err );
 			} )
 			.then( () => {
-				let config = this._config;
-
-				if ( isElement( this._elementOrData ) ) {
-					config = Object.assign( {}, this._config, {
+				if ( typeof this._elementOrData === 'string' ) {
+					return this.create( this._data, this._config );
+				} else {
+					const updatedConfig = Object.assign( {}, this._config, {
 						initialData: this._data
 					} );
-				}
 
-				return this.create( this._elementOrData, config );
+					return this.create( this._elementOrData, updatedConfig );
+				}
 			} )
 			.then( () => {
 				this.fire( 'restart' );

--- a/src/editorwatchdog.js
+++ b/src/editorwatchdog.js
@@ -242,8 +242,7 @@ export default class EditorWatchdog extends Watchdog {
 	_save() {
 		const version = this._editor.model.document.version;
 
-		// Change may not produce an operation, so the document's version
-		// can be the same after that change.
+		// Operation may not result in a model change, so the document's version can be the same.
 		if ( version === this._lastDocumentVersion ) {
 			return;
 		}
@@ -285,8 +284,8 @@ export default class EditorWatchdog extends Watchdog {
 	}
 
 	/**
-	 * Traverses both structures to find out whether the error context is connected
-	 * with the current editor.
+	 * Traverses error context and the current editor to find out whether these structures are connected
+	 * via properties to each other.
 	 *
 	 * @protected
 	 * @param {module:utils/ckeditorerror~CKEditorError} error

--- a/src/editorwatchdog.js
+++ b/src/editorwatchdog.js
@@ -143,15 +143,15 @@ export default class EditorWatchdog extends Watchdog {
 				console.error( 'An error happened during the editor destructing.', err );
 			} )
 			.then( () => {
-				if ( typeof this._elementOrData === 'string' ) {
-					return this.create( this._data, this._config );
-				} else {
-					const updatedConfig = Object.assign( {}, this._config, {
+				let config = this._config;
+
+				if ( isElement( this._elementOrData ) ) {
+					config = Object.assign( {}, this._config, {
 						initialData: this._data
 					} );
-
-					return this.create( this._elementOrData, updatedConfig );
 				}
+
+				return this.create( this._elementOrData, config );
 			} )
 			.then( () => {
 				this.fire( 'restart' );

--- a/src/editorwatchdog.js
+++ b/src/editorwatchdog.js
@@ -89,9 +89,7 @@ export default class EditorWatchdog extends Watchdog {
 	}
 
 	/**
-	 * Returns the handled instance.
-	 *
-	 * @protected
+	 * @inheritDoc
 	 */
 	get _instance() {
 		return this._editor;

--- a/src/editorwatchdog.js
+++ b/src/editorwatchdog.js
@@ -22,13 +22,6 @@ import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
  */
 export default class EditorWatchdog extends Watchdog {
 	/**
-	 * Returns the instance type of the watchdog.
-	 */
-	static get instanceType() {
-		return 'editor';
-	}
-
-	/**
 	 * @param {module:watchdog/editorwatchdog~EditorWatchdogConfig} [config] The watchdog plugin configuration.
 	 */
 	constructor( config = {} ) {
@@ -96,6 +89,15 @@ export default class EditorWatchdog extends Watchdog {
 	}
 
 	/**
+	 * Returns the handled instance.
+	 *
+	 * @protected
+	 */
+	get _instance() {
+		return this._editor;
+	}
+
+	/**
 	 * Sets the function that is responsible for the editor creation.
 	 * It expects a function that should return a promise.
 	 *
@@ -128,7 +130,7 @@ export default class EditorWatchdog extends Watchdog {
 	 * Restarts the editor instance. This method is called whenever an editor error occurs. It fires the `restart` event and changes
 	 * the state to `initializing`.
 	 *
-	 * @public
+	 * @protected
 	 * @fires restart
 	 * @returns {Promise}
 	 */

--- a/src/editorwatchdog.js
+++ b/src/editorwatchdog.js
@@ -22,6 +22,13 @@ import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
  */
 export default class EditorWatchdog extends Watchdog {
 	/**
+	 * Returns the instance type of the watchdog.
+	 */
+	static get instanceType() {
+		return 'editor';
+	}
+
+	/**
 	 * @param {module:watchdog/editorwatchdog~EditorWatchdogConfig} [config] The watchdog plugin configuration.
 	 */
 	constructor( config = {} ) {

--- a/src/editorwatchdog.js
+++ b/src/editorwatchdog.js
@@ -95,7 +95,7 @@ export default class EditorWatchdog extends Watchdog {
 	/**
 	 * @inheritDoc
 	 */
-	get _instance() {
+	get _item() {
 		return this._editor;
 	}
 
@@ -293,7 +293,7 @@ export default class EditorWatchdog extends Watchdog {
 	 * @protected
 	 * @param {module:utils/ckeditorerror~CKEditorError} error
 	 */
-	_isErrorComingFromThisInstance( error ) {
+	_isErrorComingFromThisItem( error ) {
 		return areConnectedThroughProperties( this._editor, error.context, this._excludedProps );
 	}
 

--- a/src/editorwatchdog.js
+++ b/src/editorwatchdog.js
@@ -220,6 +220,8 @@ export default class EditorWatchdog extends Watchdog {
 			.then( () => {
 				this.state = 'destroyed';
 
+				super.destroy();
+
 				return this._destroy();
 			} );
 	}

--- a/src/editorwatchdog.js
+++ b/src/editorwatchdog.js
@@ -18,6 +18,8 @@ import Watchdog from './watchdog';
  *
  * See the {@glink features/watchdog Watchdog feature guide} to learn the rationale behind it and
  * how to use it.
+ *
+ * @extends {module:watchdog/watchdog~Watchdog}
  */
 export default class EditorWatchdog extends Watchdog {
 	/**

--- a/src/utils/getsubnodes.js
+++ b/src/utils/getsubnodes.js
@@ -33,7 +33,7 @@ export default function getSubNodes( head, excludedProperties = new Set() ) {
 				for ( const n of node ) {
 					nodes.push( n );
 
-					// @if CK_DEBUG_WATCHDOG // if ( !prevNodeMap.has( node[ key ] ) ) {
+					// @if CK_DEBUG_WATCHDOG // if ( !prevNodeMap.has( n ) ) {
 					// @if CK_DEBUG_WATCHDOG // 	prevNodeMap.set( n, node );
 					// @if CK_DEBUG_WATCHDOG // }
 				}
@@ -44,17 +44,17 @@ export default function getSubNodes( head, excludedProperties = new Set() ) {
 			}
 		} else {
 			for ( const key in node ) {
-				// We share references (objects) in the ProtobufFactory within the editors,
-				// hence the whole object should be skipped. Although, it's not a perfect
+				// We share a reference via the protobuf library within the editors,
+				// hence the shared value should be skipped. Although, it's not a perfect
 				// solution since new places like that might occur in the future.
-				if ( key === 'nested' ) {
+				if ( key === 'defaultValue' ) {
 					continue;
 				}
 
 				nodes.push( node[ key ] );
 
 				// @if CK_DEBUG_WATCHDOG // if ( !prevNodeMap.has( node[ key ] ) ) {
-				// @if CK_DEBUG_WATCHDOG // 	prevNodeMap.set( n, node );
+				// @if CK_DEBUG_WATCHDOG // 	prevNodeMap.set( node[ key ], node );
 				// @if CK_DEBUG_WATCHDOG // }
 			}
 		}

--- a/src/watchdog.js
+++ b/src/watchdog.js
@@ -48,7 +48,7 @@ export default class Watchdog {
 		 * * `ready` - a state when a user can interact with the instance,
 		 * * `crashed` - a state when an error occurs - it quickly changes to `initializing` or `crashedPermanently`
 		 * depending on how many and how frequency errors have been caught recently,
-		 * * `crashedPermanently` - a state when the watchdog stops reacting to errors and keeps the instance crashed,
+		 * * `crashedPermanently` - a state when the watchdog stops reacting to errors and keeps the item it is watching crashed,
 		 * * `destroyed` - a state when the instance is manually destroyed by the user after calling `watchdog.destroy()`
 		 *
 		 * @public

--- a/src/watchdog.js
+++ b/src/watchdog.js
@@ -221,8 +221,8 @@ export default class Watchdog {
 
 			const causesRestart = this._shouldRestart();
 
-			this.fire( 'error', { error, causesRestart } );
 			this.state = 'crashed';
+			this.fire( 'error', { error, causesRestart } );
 
 			if ( causesRestart ) {
 				this._restart();

--- a/src/watchdog.js
+++ b/src/watchdog.js
@@ -275,6 +275,10 @@ export default class Watchdog {
 	 * Fired when a new {@link module:utils/ckeditorerror~CKEditorError `CKEditorError`} error connected to the watchdog instance occurs
 	 * and the watchdog will react to it.
 	 *
+	 * 	watchdog.on( 'error', ( evt, { error, causesRestart } ) => {
+	 * 		console.log( 'An error occurred.' );
+	 * 	} );
+	 *
 	 * @event error
 	 */
 }

--- a/src/watchdog.js
+++ b/src/watchdog.js
@@ -42,14 +42,6 @@ export default class Watchdog {
 		this.crashes = [];
 
 		/**
-		 * TODO
-		 *
-		 * @abstract
-		 * @protected
-		 * @method #_restart
-		 */
-
-		/**
 		 * Specifies the state of the instance handled by the watchdog. The state can be one of the following values:
 		 *
 		 * * `initializing` - before the first initialization, and after crashes, before the instance is ready,
@@ -118,6 +110,32 @@ export default class Watchdog {
 		 * @protected
 		 * @member {Function} #_destructor
 		 * @see #setDestructor
+		 */
+
+		/**
+		 * The handled instances.
+		 *
+		 * @abstract
+		 * @protected
+		 * @member {Object} #_instance
+		 */
+
+		/**
+		 * The method responsible for the instance restarting.
+		 *
+		 * @abstract
+		 * @protected
+		 * @method #_restart
+		 */
+
+		/**
+		 * Traverses the error context and the handled instance to find out whether the error should
+		 * be handled by the given instance.
+		 *
+		 * @abstract
+		 * @protected
+		 * @method #_isErrorComingFromThisInstance
+		 * @param {module:utils/ckeditorerror~CKEditorError} error
 		 */
 	}
 

--- a/src/watchdog.js
+++ b/src/watchdog.js
@@ -288,7 +288,11 @@ mix( Watchdog, ObservableMixin );
  * when the watchdog stops restarting the instance in case of errors.
  * After this limit is reached and the time between last errors is shorter than `minimumNonErrorTimePeriod`
  * the watchdog changes its state to `crashedPermanently` and it stops restarting the instance. This prevents an infinite restart loop.
+ *
  * @property {Number} [minimumNonErrorTimePeriod=5000] An average amount of milliseconds between last instance errors
  * (defaults to 5000). When the period of time between errors is lower than that and the `crashNumberLimit` is also reached
  * the watchdog changes its state to `crashedPermanently` and it stops restarting the instance. This prevents an infinite restart loop.
+ *
+ * @property {Number} [saveInterval=5000] A minimum number of milliseconds between saving editor data internally, (defaults to 5000).
+ * Note that for large documents this might have an impact on the editor performance.
  */

--- a/src/watchdog.js
+++ b/src/watchdog.js
@@ -120,11 +120,11 @@ export default class Watchdog {
 		 */
 
 		/**
-		 * The handled instances.
+		 * The handled instance.
 		 *
 		 * @abstract
 		 * @protected
-		 * @member {Object} #_instance
+		 * @member {Object|undefined} #_instance
 		 */
 
 		/**
@@ -165,6 +165,9 @@ export default class Watchdog {
 		this._destructor = destructor;
 	}
 
+	/**
+	 * Destroys the watchdog and release the resources.
+	 */
 	destroy() {
 		this._stopErrorHandling();
 		this.stopListening();

--- a/src/watchdog.js
+++ b/src/watchdog.js
@@ -159,7 +159,7 @@ export default class Watchdog {
 	 * Sets the function that is responsible for the instance destruction.
 	 *
 	 * @param {Function} destructor A callback that takes the instance and returns the promise
-	 * to the destructing process.
+	 * to the destroying process.
 	 */
 	setDestructor( destructor ) {
 		this._destructor = destructor;

--- a/src/watchdog.js
+++ b/src/watchdog.js
@@ -216,7 +216,7 @@ export default class Watchdog {
 	 *
 	 * @protected
 	 * @param {String} eventName Event name.
-	 * @param  {...any} args Event arguments.
+	 * @param  {...*} args Event arguments.
 	 */
 	_fire( eventName, ...args ) {
 		const callbacks = this._listeners[ eventName ] || [];

--- a/src/watchdog.js
+++ b/src/watchdog.js
@@ -165,6 +165,11 @@ export default class Watchdog {
 		this._destructor = destructor;
 	}
 
+	destroy() {
+		this._stopErrorHandling();
+		this.stopListening();
+	}
+
 	/**
 	 * Starts error handling by attaching global error handlers.
 	 *

--- a/src/watchdog.js
+++ b/src/watchdog.js
@@ -219,10 +219,12 @@ export default class Watchdog {
 				date: this._now()
 			} );
 
-			this.fire( 'error', { error } );
+			const causesRestart = this._shouldRestart();
+
+			this.fire( 'error', { error, causesRestart } );
 			this.state = 'crashed';
 
-			if ( this._shouldRestart() ) {
+			if ( causesRestart ) {
 				this._restart();
 			} else {
 				this.state = 'crashedPermanently';

--- a/src/watchdog.js
+++ b/src/watchdog.js
@@ -96,6 +96,13 @@ export default class Watchdog {
 			}
 		};
 
+		if ( !this._restart ) {
+			throw new Error(
+				'The Watchdog class was split into the abstract `Watchdog` class and the `EditorWatchdog` class. ' +
+				'Please, use `EditorWatchdog` if you have used the `Watchdog` class previously.'
+			);
+		}
+
 		/**
 		 * The creation method.
 		 *

--- a/src/watchdog.js
+++ b/src/watchdog.js
@@ -42,14 +42,14 @@ export default class Watchdog {
 		this.crashes = [];
 
 		/**
-		 * Specifies the state of the instance handled by the watchdog. The state can be one of the following values:
+		 * Specifies the state of the watchdog item handled by the watchdog. The state can be one of the following values:
 		 *
-		 * * `initializing` - before the first initialization, and after crashes, before the instance is ready,
-		 * * `ready` - a state when a user can interact with the instance,
+		 * * `initializing` - before the first initialization, and after crashes, before the item is ready,
+		 * * `ready` - a state when a user can interact with the item,
 		 * * `crashed` - a state when an error occurs - it quickly changes to `initializing` or `crashedPermanently`
 		 * depending on how many and how frequency errors have been caught recently,
 		 * * `crashedPermanently` - a state when the watchdog stops reacting to errors and keeps the item it is watching crashed,
-		 * * `destroyed` - a state when the instance is manually destroyed by the user after calling `watchdog.destroy()`
+		 * * `destroyed` - a state when the item is manually destroyed by the user after calling `watchdog.destroy()`
 		 *
 		 * @public
 		 * @observable
@@ -80,7 +80,7 @@ export default class Watchdog {
 		this._minimumNonErrorTimePeriod = typeof config.minimumNonErrorTimePeriod === 'number' ? config.minimumNonErrorTimePeriod : 5000;
 
 		/**
-		 * Checks if the event error comes from the underlying instance and restarts the instance.
+		 * Checks if the event error comes from the underlying item and restarts the item.
 		 *
 		 * @private
 		 * @type {Function}
@@ -120,15 +120,15 @@ export default class Watchdog {
 		 */
 
 		/**
-		 * The handled instance.
+		 * The handled watchdog item.
 		 *
 		 * @abstract
 		 * @protected
-		 * @member {Object|undefined} #_instance
+		 * @member {Object|undefined} #_item
 		 */
 
 		/**
-		 * The method responsible for the instance restarting.
+		 * The method responsible for the watchdog item restarting.
 		 *
 		 * @abstract
 		 * @protected
@@ -136,30 +136,30 @@ export default class Watchdog {
 		 */
 
 		/**
-		 * Traverses the error context and the handled instance to find out whether the error should
-		 * be handled by the given instance.
+		 * Traverses the error context and the handled watchdog item to find out whether the error should
+		 * be handled by the given item.
 		 *
 		 * @abstract
 		 * @protected
-		 * @method #_isErrorComingFromThisInstance
+		 * @method #_isErrorComingFromThisItem
 		 * @param {module:utils/ckeditorerror~CKEditorError} error
 		 */
 	}
 
 	/**
-	 * Sets the function that is responsible for the instance creation.
+	 * Sets the function that is responsible for the watchdog item creation.
 	 *
-	 * @param {Function} creator A callback responsible for creating instance. Returns a promise
-	 * that is resolved when the instance is created.
+	 * @param {Function} creator A callback responsible for creating an item. Returns a promise
+	 * that is resolved when the item is created.
 	 */
 	setCreator( creator ) {
 		this._creator = creator;
 	}
 
 	/**
-	 * Sets the function that is responsible for the instance destruction.
+	 * Sets the function that is responsible for the watchdog item destruction.
 	 *
-	 * @param {Function} destructor A callback that takes the instance and returns the promise
+	 * @param {Function} destructor A callback that takes the item and returns the promise
 	 * to the destroying process.
 	 */
 	setDestructor( destructor ) {
@@ -195,8 +195,8 @@ export default class Watchdog {
 	}
 
 	/**
-	 * Checks if the error comes from the instance that is handled by the watchdog  and
-	 * restarts it. It reacts to {@link module:utils/ckeditorerror~CKEditorError `CKEditorError` errors} only.
+	 * Checks if the error comes from the watchdog item and restarts it.
+	 * It reacts to {@link module:utils/ckeditorerror~CKEditorError `CKEditorError` errors} only.
 	 *
 	 * @private
 	 * @fires error
@@ -205,7 +205,7 @@ export default class Watchdog {
 	 */
 	_handleError( error, evt ) {
 		// @if CK_DEBUG // if ( error.is && error.is( 'CKEditorError' ) && error.context === undefined ) {
-		// @if CK_DEBUG // console.warn( 'The error is missing its context and Watchdog cannot restart the proper instance.' );
+		// @if CK_DEBUG // console.warn( 'The error is missing its context and Watchdog cannot restart the proper item.' );
 		// @if CK_DEBUG // }
 
 		if ( this._shouldReactToError( error ) ) {
@@ -245,19 +245,19 @@ export default class Watchdog {
 			error.is( 'CKEditorError' ) &&
 			error.context !== undefined &&
 
-			// In some cases the instance should not be restarted - e.g. during the instance initialization.
+			// In some cases the watchdog item should not be restarted - e.g. during the item initialization.
 			// That's why the `null` was introduced as a correct error context which does cause restarting.
 			error.context !== null &&
 
 			// Do not react to errors if the watchdog is in states other than `ready`.
 			this.state === 'ready' &&
 
-			this._isErrorComingFromThisInstance( error )
+			this._isErrorComingFromThisItem( error )
 		);
 	}
 
 	/**
-	 * Checks if the watchdog should restart the underlying instance.
+	 * Checks if the watchdog should restart the underlying item.
 	 */
 	_shouldRestart() {
 		if ( this.crashes.length <= this._crashNumberLimit ) {
@@ -291,14 +291,14 @@ mix( Watchdog, ObservableMixin );
  *
  * @typedef {Object} WatchdogConfig
  *
- * @property {Number} [crashNumberLimit=3] A threshold specifying the number of instance crashes
- * when the watchdog stops restarting the instance in case of errors.
+ * @property {Number} [crashNumberLimit=3] A threshold specifying the number of watchdog item crashes
+ * when the watchdog stops restarting the item in case of errors.
  * After this limit is reached and the time between last errors is shorter than `minimumNonErrorTimePeriod`
- * the watchdog changes its state to `crashedPermanently` and it stops restarting the instance. This prevents an infinite restart loop.
+ * the watchdog changes its state to `crashedPermanently` and it stops restarting the item. This prevents an infinite restart loop.
  *
- * @property {Number} [minimumNonErrorTimePeriod=5000] An average amount of milliseconds between last instance errors
+ * @property {Number} [minimumNonErrorTimePeriod=5000] An average amount of milliseconds between last watchdog item errors
  * (defaults to 5000). When the period of time between errors is lower than that and the `crashNumberLimit` is also reached
- * the watchdog changes its state to `crashedPermanently` and it stops restarting the instance. This prevents an infinite restart loop.
+ * the watchdog changes its state to `crashedPermanently` and it stops restarting the item. This prevents an infinite restart loop.
  *
  * @property {Number} [saveInterval=5000] A minimum number of milliseconds between saving editor data internally, (defaults to 5000).
  * Note that for large documents this might have an impact on the editor performance.

--- a/src/watchdog.js
+++ b/src/watchdog.js
@@ -149,7 +149,8 @@ export default class Watchdog {
 	/**
 	 * Sets the function that is responsible for the instance creation.
 	 *
-	 * @param {Function} creator A callback returning promise that is responsible for instance creation.
+	 * @param {Function} creator A callback responsible for creating instance. Returns a promise
+	 * that is resolved when the instance is created.
 	 */
 	setCreator( creator ) {
 		this._creator = creator;

--- a/tests/areconnectedthroughproperties.js
+++ b/tests/areconnectedthroughproperties.js
@@ -230,12 +230,21 @@ describe( 'areConnectedThroughProperties()', () => {
 		expect( areConnectedThroughProperties( el1, el2, new Set( [ shared ] ) ) ).to.be.true;
 	} );
 
-	it( 'should skip the `nested` key since we share props withing ', () => {
+	it( 'should skip the `defaultValue` key since its commonly shared between editors', () => {
 		const shared = {};
 
-		const el1 = { nested: shared };
-		const el2 = { nested: shared };
+		const el1 = { defaultValue: shared };
+		const el2 = { defaultValue: shared };
 
 		expect( areConnectedThroughProperties( el1, el2 ) ).to.be.false;
+	} );
+
+	it( 'should skip the `defaultValue` key since its commonly shared between editors #2', () => {
+		const shared = {};
+
+		const el1 = { defaultValue: shared, shared };
+		const el2 = { defaultValue: shared, shared };
+
+		expect( areConnectedThroughProperties( el1, el2 ) ).to.be.true;
 	} );
 } );

--- a/tests/contextwatchdog.js
+++ b/tests/contextwatchdog.js
@@ -105,7 +105,7 @@ describe( 'ContextWatchdog', () => {
 			sinon.assert.calledOnce( customDestructor );
 		} );
 
-		it( 'should log if an error happens during the component destructing', async () => {
+		it( 'should log if an error happens during the component destroying', async () => {
 			const mainWatchdog = new ContextWatchdog( Context );
 
 			const consoleErrorStub = sinon.stub( console, 'error' );
@@ -122,7 +122,7 @@ describe( 'ContextWatchdog', () => {
 
 			sinon.assert.calledWith(
 				consoleErrorStub,
-				'An error happened during destructing.',
+				'An error happened during destroying the context or items.',
 				err
 			);
 

--- a/tests/contextwatchdog.js
+++ b/tests/contextwatchdog.js
@@ -234,7 +234,7 @@ describe( 'ContextWatchdog', () => {
 			await watchdog.destroy();
 
 			expect( err ).to.be.instanceOf( Error );
-			expect( err.message ).to.match( /There is no watchdog named: 'foo'\./ );
+			expect( err.message ).to.match( /Item with the given name was not registered: foo\./ );
 		} );
 
 		it( 'should throw when the item is added before the context is created', async () => {

--- a/tests/contextwatchdog.js
+++ b/tests/contextwatchdog.js
@@ -132,14 +132,19 @@ describe( 'ContextWatchdog', () => {
 		} );
 
 		it( 'should handle the Watchdog configuration', async () => {
-			// TODO
-			const mainWatchdog = new ContextWatchdog( Context, {
-				crashNumberLimit: Infinity
+			watchdog = new ContextWatchdog( Context, {
+				crashNumberLimit: 0
 			} );
 
-			await mainWatchdog.create();
+			await watchdog.create();
 
-			await mainWatchdog.destroy();
+			setTimeout( () => throwCKEditorError( 'foo', watchdog.context ) );
+
+			await waitCycle();
+
+			expect( watchdog.state ).to.equal( 'crashedPermanently' );
+
+			await watchdog.destroy();
 		} );
 
 		describe( 'in case of error handling', () => {

--- a/tests/contextwatchdog.js
+++ b/tests/contextwatchdog.js
@@ -12,7 +12,7 @@ import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 
 describe( 'ContextWatchdog', () => {
 	let element1, element2;
-	let mainWatchdog;
+	let watchdog;
 	let originalErrorHandler;
 
 	beforeEach( () => {
@@ -36,14 +36,14 @@ describe( 'ContextWatchdog', () => {
 	} );
 
 	it( 'should disable adding items once the Watchdog is destroyed', async () => {
-		mainWatchdog = ContextWatchdog.for( Context, {} );
+		watchdog = ContextWatchdog.for( Context, {} );
 
-		await mainWatchdog.destroy();
+		await watchdog.destroy();
 
 		let err;
 
 		try {
-			await mainWatchdog.add( {
+			await watchdog.add( {
 				editor2: {
 					type: 'editor',
 					creator: ( el, config ) => ClassicTestEditor.create( el, config ),
@@ -60,9 +60,9 @@ describe( 'ContextWatchdog', () => {
 	} );
 
 	it.skip( 'case: editor, contextItem', async () => {
-		mainWatchdog = ContextWatchdog.for( Context, {} );
+		watchdog = ContextWatchdog.for( Context, {} );
 
-		mainWatchdog.add( {
+		watchdog.add( {
 			editor1: {
 				type: 'editor',
 				creator: ( el, config ) => ClassicTestEditor.create( el, config ),
@@ -75,34 +75,34 @@ describe( 'ContextWatchdog', () => {
 			}
 		} );
 
-		await mainWatchdog.waitForReady();
+		await watchdog.waitForReady();
 
-		await mainWatchdog.destroy();
+		await watchdog.destroy();
 	} );
 
 	describe( 'for scenario with no items', () => {
 		it( 'should create only context', async () => {
-			mainWatchdog = ContextWatchdog.for( Context, {} );
+			watchdog = ContextWatchdog.for( Context, {} );
 
-			await mainWatchdog.waitForReady();
+			await watchdog.waitForReady();
 
-			expect( mainWatchdog.context ).to.be.instanceOf( Context );
+			expect( watchdog.context ).to.be.instanceOf( Context );
 
-			await mainWatchdog.destroy();
+			await watchdog.destroy();
 		} );
 
 		it( 'should have proper states', async () => {
-			mainWatchdog = ContextWatchdog.for( Context, {} );
+			watchdog = ContextWatchdog.for( Context, {} );
 
-			expect( mainWatchdog.state ).to.equal( 'initializing' );
+			expect( watchdog.state ).to.equal( 'initializing' );
 
-			await mainWatchdog.waitForReady();
+			await watchdog.waitForReady();
 
-			expect( mainWatchdog.state ).to.equal( 'ready' );
+			expect( watchdog.state ).to.equal( 'ready' );
 
-			await mainWatchdog.destroy();
+			await watchdog.destroy();
 
-			expect( mainWatchdog.state ).to.equal( 'destroyed' );
+			expect( watchdog.state ).to.equal( 'destroyed' );
 		} );
 
 		it( 'should set custom destructor if provided', async () => {
@@ -158,31 +158,31 @@ describe( 'ContextWatchdog', () => {
 
 		describe( 'in case of error handling', () => {
 			it( 'should restart the `Context`', async () => {
-				mainWatchdog = ContextWatchdog.for( Context, {} );
+				watchdog = ContextWatchdog.for( Context, {} );
 				const errorSpy = sinon.spy();
 
-				await mainWatchdog.waitForReady();
+				await watchdog.waitForReady();
 
-				const oldContext = mainWatchdog.context;
+				const oldContext = watchdog.context;
 
-				mainWatchdog.on( 'restart', errorSpy );
+				watchdog.on( 'restart', errorSpy );
 
-				setTimeout( () => throwCKEditorError( 'foo', mainWatchdog.context ) );
+				setTimeout( () => throwCKEditorError( 'foo', watchdog.context ) );
 
 				await waitCycle();
 
 				sinon.assert.calledOnce( errorSpy );
 
-				expect( mainWatchdog.context ).to.not.equal( oldContext );
+				expect( watchdog.context ).to.not.equal( oldContext );
 			} );
 		} );
 	} );
 
 	describe( 'for multiple items scenario', () => {
 		it( 'should allow adding multiple items without waiting for promises', async () => {
-			mainWatchdog = ContextWatchdog.for( Context, {} );
+			watchdog = ContextWatchdog.for( Context, {} );
 
-			mainWatchdog.add( {
+			watchdog.add( {
 				editor1: {
 					type: 'editor',
 					creator: ( el, config ) => ClassicTestEditor.create( el, config ),
@@ -191,7 +191,7 @@ describe( 'ContextWatchdog', () => {
 				},
 			} );
 
-			mainWatchdog.add( {
+			watchdog.add( {
 				editor2: {
 					type: 'editor',
 					creator: ( el, config ) => ClassicTestEditor.create( el, config ),
@@ -200,15 +200,15 @@ describe( 'ContextWatchdog', () => {
 				},
 			} );
 
-			await mainWatchdog.waitForReady();
+			await watchdog.waitForReady();
 
-			await mainWatchdog.destroy();
+			await watchdog.destroy();
 		} );
 
 		it( 'should throw when multiple items with the same name are added', async () => {
-			mainWatchdog = ContextWatchdog.for( Context, {} );
+			watchdog = ContextWatchdog.for( Context, {} );
 
-			mainWatchdog.add( {
+			watchdog.add( {
 				editor1: {
 					type: 'editor',
 					creator: ( el, config ) => ClassicTestEditor.create( el, config ),
@@ -217,11 +217,11 @@ describe( 'ContextWatchdog', () => {
 				},
 			} );
 
-			await mainWatchdog.waitForReady();
+			await watchdog.waitForReady();
 
 			let err;
 			try {
-				await mainWatchdog.add( {
+				await watchdog.add( {
 					editor1: {
 						type: 'editor',
 						creator: ( el, config ) => ClassicTestEditor.create( el, config ),
@@ -233,30 +233,30 @@ describe( 'ContextWatchdog', () => {
 				err = _err;
 			}
 
-			mainWatchdog._actionQueue._clear();
+			watchdog._actionQueue._clear();
 
-			await mainWatchdog.destroy();
+			await watchdog.destroy();
 
 			expect( err ).to.be.instanceOf( Error );
-			expect( err.message ).to.match( /Watchdog with the given name is already added: 'editor1'./ );
+			expect( err.message ).to.match( /Item with the given name is already added: 'editor1'./ );
 		} );
 
 		it( 'should throw when not added item is removed', async () => {
-			mainWatchdog = ContextWatchdog.for( Context, {} );
+			watchdog = ContextWatchdog.for( Context, {} );
 
-			await mainWatchdog.waitForReady();
+			await watchdog.waitForReady();
 
 			let err;
 
 			try {
-				await mainWatchdog.remove( [ 'foo' ] );
+				await watchdog.remove( [ 'foo' ] );
 			} catch ( _err ) {
 				err = _err;
 			}
 
-			mainWatchdog._actionQueue._clear();
+			watchdog._actionQueue._clear();
 
-			await mainWatchdog.destroy();
+			await watchdog.destroy();
 
 			expect( err ).to.be.instanceOf( Error );
 			expect( err.message ).to.match( /There is no watchdog named: 'foo'\./ );
@@ -279,11 +279,11 @@ describe( 'ContextWatchdog', () => {
 		} );
 
 		it( 'should allow setting editor custom destructors', async () => {
-			mainWatchdog = ContextWatchdog.for( Context, {} );
+			watchdog = ContextWatchdog.for( Context, {} );
 
 			const destructorSpy = sinon.spy( editor => editor.destroy() );
 
-			mainWatchdog.add( {
+			watchdog.add( {
 				editor1: {
 					type: 'editor',
 					creator: ( el, config ) => ClassicTestEditor.create( el, config ),
@@ -293,19 +293,19 @@ describe( 'ContextWatchdog', () => {
 				},
 			} );
 
-			await mainWatchdog.destroy();
+			await watchdog.destroy();
 
 			sinon.assert.calledOnce( destructorSpy );
 		} );
 
 		it( 'should throw when the item is of not known type', async () => {
-			mainWatchdog = ContextWatchdog.for( Context, {} );
+			watchdog = ContextWatchdog.for( Context, {} );
 
-			await mainWatchdog.waitForReady();
+			await watchdog.waitForReady();
 
 			let err;
 			try {
-				await mainWatchdog.add( {
+				await watchdog.add( {
 					editor1: {
 						type: 'foo',
 						creator: ( el, config ) => ClassicTestEditor.create( el, config ),
@@ -314,22 +314,22 @@ describe( 'ContextWatchdog', () => {
 					},
 				} );
 			} catch ( _err ) {
-				mainWatchdog._stopErrorHandling();
+				watchdog._stopErrorHandling();
 				err = _err;
 			}
 
-			mainWatchdog._actionQueue._clear();
+			watchdog._actionQueue._clear();
 
-			await mainWatchdog.destroy();
+			await watchdog.destroy();
 
 			expect( err ).to.be.instanceOf( Error );
 			expect( err.message ).to.match( /Not supported item type: 'foo'\./ );
 		} );
 
 		it( 'should allow adding and removing items without waiting', async () => {
-			mainWatchdog = ContextWatchdog.for( Context, {} );
+			watchdog = ContextWatchdog.for( Context, {} );
 
-			mainWatchdog.add( {
+			watchdog.add( {
 				editor1: {
 					type: 'editor',
 					creator: ( el, config ) => ClassicTestEditor.create( el, config ),
@@ -338,7 +338,7 @@ describe( 'ContextWatchdog', () => {
 				},
 			} );
 
-			mainWatchdog.add( {
+			watchdog.add( {
 				editor2: {
 					type: 'editor',
 					creator: ( el, config ) => ClassicTestEditor.create( el, config ),
@@ -347,25 +347,25 @@ describe( 'ContextWatchdog', () => {
 				},
 			} );
 
-			await mainWatchdog.waitForReady();
+			await watchdog.waitForReady();
 
-			expect( mainWatchdog.state ).to.equal( 'ready' );
+			expect( watchdog.state ).to.equal( 'ready' );
 
-			mainWatchdog.remove( [ 'editor1' ] );
+			watchdog.remove( [ 'editor1' ] );
 
-			await mainWatchdog.waitForReady();
+			await watchdog.waitForReady();
 
-			mainWatchdog.remove( [ 'editor2' ] );
+			watchdog.remove( [ 'editor2' ] );
 
-			await mainWatchdog.waitForReady();
+			await watchdog.waitForReady();
 
-			await mainWatchdog.destroy();
+			await watchdog.destroy();
 		} );
 
 		it( 'should not change the input items', async () => {
-			mainWatchdog = ContextWatchdog.for( Context, {} );
+			watchdog = ContextWatchdog.for( Context, {} );
 
-			mainWatchdog.add( Object.freeze( {
+			watchdog.add( Object.freeze( {
 				editor1: {
 					type: 'editor',
 					creator: ( el, config ) => ClassicTestEditor.create( el, config ),
@@ -374,17 +374,51 @@ describe( 'ContextWatchdog', () => {
 				}
 			} ) );
 
-			mainWatchdog._restart();
+			watchdog._restart();
 
-			await mainWatchdog.waitForReady();
+			await watchdog.waitForReady();
 
-			await mainWatchdog.destroy();
+			await watchdog.destroy();
+		} );
+
+		it( 'should return the created items instances with get( itemName )', async () => {
+			watchdog = ContextWatchdog.for( Context, {} );
+
+			watchdog.add( {
+				editor1: {
+					type: 'editor',
+					creator: ( el, config ) => ClassicTestEditor.create( el, config ),
+					sourceElementOrData: element1,
+					config: {}
+				},
+				editor2: {
+					type: 'editor',
+					creator: ( el, config ) => ClassicTestEditor.create( el, config ),
+					sourceElementOrData: element2,
+					config: {}
+				}
+			} );
+
+			await watchdog.waitForReady();
+
+			expect( watchdog.get( 'editor1' ) ).to.be.instanceOf( ClassicTestEditor );
+			expect( watchdog.get( 'editor2' ) ).to.be.instanceOf( ClassicTestEditor );
+
+			await watchdog.remove( [ 'editor1' ] );
+
+			expect( () => {
+				watchdog.get( 'editor1' );
+			} ).to.throw( /Item with the given name was not registered: editor1\./ );
+
+			expect( watchdog.get( 'editor2' ) ).to.be.instanceOf( ClassicTestEditor );
+
+			await watchdog.destroy();
 		} );
 
 		describe( 'in case of error handling', () => {
 			it( 'should restart the whole structure of editors if an error happens inside the `Context`', async () => {
-				mainWatchdog = ContextWatchdog.for( Context, {} );
-				mainWatchdog.add( {
+				watchdog = ContextWatchdog.for( Context, {} );
+				watchdog.add( {
 					editor1: {
 						type: 'editor',
 						creator: ( el, config ) => ClassicTestEditor.create( el, config ),
@@ -393,28 +427,28 @@ describe( 'ContextWatchdog', () => {
 					}
 				} );
 
-				await mainWatchdog.waitForReady();
+				await watchdog.waitForReady();
 
-				const oldContext = mainWatchdog.context;
+				const oldContext = watchdog.context;
 				const restartSpy = sinon.spy();
 
-				mainWatchdog.on( 'restart', restartSpy );
+				watchdog.on( 'restart', restartSpy );
 
-				setTimeout( () => throwCKEditorError( 'foo', mainWatchdog.context ) );
+				setTimeout( () => throwCKEditorError( 'foo', watchdog.context ) );
 
 				await waitCycle();
 
 				sinon.assert.calledOnce( restartSpy );
 
-				expect( mainWatchdog._watchdogs.get( 'editor1' ).state ).to.equal( 'ready' );
-				expect( mainWatchdog.context ).to.not.equal( oldContext );
+				expect( watchdog._watchdogs.get( 'editor1' ).state ).to.equal( 'ready' );
+				expect( watchdog.context ).to.not.equal( oldContext );
 
-				await mainWatchdog.destroy();
+				await watchdog.destroy();
 			} );
 
 			it( 'should restart only the editor if an error happens inside the editor', async () => {
-				mainWatchdog = ContextWatchdog.for( Context, {} );
-				mainWatchdog.add( {
+				watchdog = ContextWatchdog.for( Context, {} );
+				watchdog.add( {
 					editor1: {
 						type: 'editor',
 						creator: ( el, config ) => ClassicTestEditor.create( el, config ),
@@ -423,14 +457,14 @@ describe( 'ContextWatchdog', () => {
 					}
 				} );
 
-				await mainWatchdog.waitForReady();
+				await watchdog.waitForReady();
 
-				const oldContext = mainWatchdog.context;
+				const oldContext = watchdog.context;
 				const restartSpy = sinon.spy();
 
-				const oldEditor = mainWatchdog.getWatchdog( 'editor1' ).editor;
+				const oldEditor = watchdog.get( 'editor1' );
 
-				mainWatchdog.on( 'restart', restartSpy );
+				watchdog.on( 'restart', restartSpy );
 
 				setTimeout( () => throwCKEditorError( 'foo', oldEditor ) );
 
@@ -438,18 +472,17 @@ describe( 'ContextWatchdog', () => {
 
 				sinon.assert.notCalled( restartSpy );
 
-				expect( mainWatchdog.context ).to.equal( oldContext );
+				expect( watchdog.context ).to.equal( oldContext );
 
-				expect( mainWatchdog.getWatchdog( 'editor1' ).editor ).to.not.equal( oldEditor );
-				expect( mainWatchdog.getWatchdog( 'editor1' ).state ).to.equal( 'ready' );
+				expect( watchdog.get( 'editor1' ) ).to.not.equal( oldEditor );
 
-				await mainWatchdog.destroy();
+				await watchdog.destroy();
 			} );
 
 			it( 'should restart only the editor if an error happens inside one of the editors', async () => {
-				mainWatchdog = ContextWatchdog.for( Context, {} );
+				watchdog = ContextWatchdog.for( Context, {} );
 
-				mainWatchdog.add( {
+				watchdog.add( {
 					editor1: {
 						type: 'editor',
 						creator: ( el, config ) => ClassicTestEditor.create( el, config ),
@@ -459,26 +492,26 @@ describe( 'ContextWatchdog', () => {
 					editor2: {
 						type: 'editor',
 						creator: ( el, config ) => ClassicTestEditor.create( el, config ),
-						sourceElementOrData: element1,
+						sourceElementOrData: element2,
 						config: {}
 					}
 				} );
 
-				await mainWatchdog.waitForReady();
+				await watchdog.waitForReady();
 
-				const oldContext = mainWatchdog.context;
+				const oldContext = watchdog.context;
 
-				const editorWatchdog1 = mainWatchdog.getWatchdog( 'editor1' );
-				const editorWatchdog2 = mainWatchdog.getWatchdog( 'editor2' );
+				const editorWatchdog1 = watchdog._watchdogs.get( 'editor1' );
+				const editorWatchdog2 = watchdog._watchdogs.get( 'editor2' );
 
-				const oldEditor1 = editorWatchdog1.editor;
-				const oldEditor2 = editorWatchdog2.editor;
+				const oldEditor1 = watchdog.get( 'editor1' );
+				const oldEditor2 = watchdog.get( 'editor2' );
 
 				const mainWatchdogRestartSpy = sinon.spy();
 				const editorWatchdog1RestartSpy = sinon.spy();
 				const editorWatchdog2RestartSpy = sinon.spy();
 
-				mainWatchdog.on( 'restart', mainWatchdogRestartSpy );
+				watchdog.on( 'restart', mainWatchdogRestartSpy );
 				editorWatchdog1.on( 'restart', editorWatchdog1RestartSpy );
 				editorWatchdog2.on( 'restart', editorWatchdog2RestartSpy );
 
@@ -493,14 +526,14 @@ describe( 'ContextWatchdog', () => {
 
 				expect( editorWatchdog1.state ).to.equal( 'ready' );
 				expect( editorWatchdog2.state ).to.equal( 'ready' );
-				expect( mainWatchdog.state ).to.equal( 'ready' );
+				expect( watchdog.state ).to.equal( 'ready' );
 
 				expect( oldEditor1 ).to.not.equal( editorWatchdog1.editor );
 				expect( oldEditor2 ).to.equal( editorWatchdog2.editor );
 
-				expect( mainWatchdog.context ).to.equal( oldContext );
+				expect( watchdog.context ).to.equal( oldContext );
 
-				await mainWatchdog.destroy();
+				await watchdog.destroy();
 			} );
 		} );
 	} );

--- a/tests/contextwatchdog.js
+++ b/tests/contextwatchdog.js
@@ -346,7 +346,7 @@ describe( 'ContextWatchdog', () => {
 			await watchdog.destroy();
 		} );
 
-		it( 'should return the created items instances with ContextWatchdog#get( itemId )', async () => {
+		it( 'should return the created items instances with ContextWatchdog#getItem( itemId )', async () => {
 			watchdog = new ContextWatchdog( Context );
 
 			watchdog.create();
@@ -365,16 +365,16 @@ describe( 'ContextWatchdog', () => {
 				config: {}
 			} ] );
 
-			expect( watchdog.get( 'editor1' ) ).to.be.instanceOf( ClassicTestEditor );
-			expect( watchdog.get( 'editor2' ) ).to.be.instanceOf( ClassicTestEditor );
+			expect( watchdog.getItem( 'editor1' ) ).to.be.instanceOf( ClassicTestEditor );
+			expect( watchdog.getItem( 'editor2' ) ).to.be.instanceOf( ClassicTestEditor );
 
 			await watchdog.remove( 'editor1' );
 
 			expect( () => {
-				watchdog.get( 'editor1' );
+				watchdog.getItem( 'editor1' );
 			} ).to.throw( /Item with the given id was not registered: editor1\./ );
 
-			expect( watchdog.get( 'editor2' ) ).to.be.instanceOf( ClassicTestEditor );
+			expect( watchdog.getItem( 'editor2' ) ).to.be.instanceOf( ClassicTestEditor );
 
 			await watchdog.destroy();
 		} );
@@ -404,7 +404,7 @@ describe( 'ContextWatchdog', () => {
 
 				sinon.assert.calledOnce( restartSpy );
 
-				expect( watchdog.getState( 'editor1' ) ).to.equal( 'ready' );
+				expect( watchdog.getItemState( 'editor1' ) ).to.equal( 'ready' );
 				expect( watchdog.context ).to.not.equal( oldContext );
 
 				await watchdog.destroy();
@@ -426,7 +426,7 @@ describe( 'ContextWatchdog', () => {
 				const oldContext = watchdog.context;
 				const restartSpy = sinon.spy();
 
-				const oldEditor = watchdog.get( 'editor1' );
+				const oldEditor = watchdog.getItem( 'editor1' );
 
 				watchdog.on( 'restart', restartSpy );
 
@@ -438,7 +438,7 @@ describe( 'ContextWatchdog', () => {
 
 				expect( watchdog.context ).to.equal( oldContext );
 
-				expect( watchdog.get( 'editor1' ) ).to.not.equal( oldEditor );
+				expect( watchdog.getItem( 'editor1' ) ).to.not.equal( oldEditor );
 
 				await watchdog.destroy();
 			} );
@@ -464,11 +464,11 @@ describe( 'ContextWatchdog', () => {
 
 				const oldContext = watchdog.context;
 
-				const editorWatchdog1 = watchdog._watchdogs.get( 'editor1' );
-				const editorWatchdog2 = watchdog._watchdogs.get( 'editor2' );
+				const editorWatchdog1 = watchdog._getWatchdog( 'editor1' );
+				const editorWatchdog2 = watchdog._getWatchdog( 'editor2' );
 
-				const oldEditor1 = watchdog.get( 'editor1' );
-				const oldEditor2 = watchdog.get( 'editor2' );
+				const oldEditor1 = watchdog.getItem( 'editor1' );
+				const oldEditor2 = watchdog.getItem( 'editor2' );
 
 				const mainWatchdogRestartSpy = sinon.spy();
 				const editorWatchdog1RestartSpy = sinon.spy();
@@ -487,8 +487,8 @@ describe( 'ContextWatchdog', () => {
 				sinon.assert.notCalled( mainWatchdogRestartSpy );
 				sinon.assert.notCalled( editorWatchdog2RestartSpy );
 
-				expect( watchdog.getState( 'editor1' ) ).to.equal( 'ready' );
-				expect( watchdog.getState( 'editor2' ) ).to.equal( 'ready' );
+				expect( watchdog.getItemState( 'editor1' ) ).to.equal( 'ready' );
+				expect( watchdog.getItemState( 'editor2' ) ).to.equal( 'ready' );
 				expect( watchdog.state ).to.equal( 'ready' );
 
 				expect( oldEditor1 ).to.not.equal( editorWatchdog1.editor );
@@ -518,7 +518,7 @@ describe( 'ContextWatchdog', () => {
 					config: {}
 				} ] );
 
-				const editor1 = watchdog.get( 'editor1' );
+				const editor1 = watchdog.getItem( 'editor1' );
 
 				const removePromise = watchdog.remove( 'editor1' );
 
@@ -527,8 +527,8 @@ describe( 'ContextWatchdog', () => {
 				await waitCycle();
 				await removePromise;
 
-				expect( [ ...watchdog._watchdogs.keys() ] ).to.include( 'editor2' );
-				expect( [ ...watchdog._watchdogs.keys() ] ).to.not.include( 'editor1' );
+				expect( Array.from( watchdog._watchdogs.keys() ) ).to.include( 'editor2' );
+				expect( Array.from( watchdog._watchdogs.keys() ) ).to.not.include( 'editor1' );
 
 				await watchdog.destroy();
 			} );
@@ -552,14 +552,14 @@ describe( 'ContextWatchdog', () => {
 					config: {}
 				} ] );
 
-				setTimeout( () => throwCKEditorError( 'foo', watchdog.get( 'editor1' ) ) );
-				setTimeout( () => throwCKEditorError( 'foo', watchdog.get( 'editor1' ) ) );
-				setTimeout( () => throwCKEditorError( 'foo', watchdog.get( 'editor1' ) ) );
-				setTimeout( () => throwCKEditorError( 'foo', watchdog.get( 'editor1' ) ) );
+				setTimeout( () => throwCKEditorError( 'foo', watchdog.getItem( 'editor1' ) ) );
+				setTimeout( () => throwCKEditorError( 'foo', watchdog.getItem( 'editor1' ) ) );
+				setTimeout( () => throwCKEditorError( 'foo', watchdog.getItem( 'editor1' ) ) );
+				setTimeout( () => throwCKEditorError( 'foo', watchdog.getItem( 'editor1' ) ) );
 
 				await waitCycle();
 
-				expect( watchdog.getState( 'editor1' ) ).to.equal( 'crashedPermanently' );
+				expect( watchdog.getItemState( 'editor1' ) ).to.equal( 'crashedPermanently' );
 				expect( watchdog.state ).to.equal( 'ready' );
 
 				await watchdog.destroy();
@@ -586,11 +586,11 @@ describe( 'ContextWatchdog', () => {
 							return data.itemId === 'editor1';
 						} ) )
 						.callsFake( () => {
-							expect( watchdog.get( 'editor1' ).state ).to.equal( 'crashed' );
+							expect( watchdog.getItemState( 'editor1' ) ).to.equal( 'crashed' );
 						} )
 				);
 
-				setTimeout( () => throwCKEditorError( 'foo', watchdog.get( 'editor1' ) ) );
+				setTimeout( () => throwCKEditorError( 'foo', watchdog.getItem( 'editor1' ) ) );
 
 				await waitCycle();
 
@@ -620,11 +620,11 @@ describe( 'ContextWatchdog', () => {
 							return data.itemId === 'editor1';
 						} ) )
 						.callsFake( () => {
-							expect( watchdog.get( 'editor1' ).state ).to.equal( 'ready' );
+							expect( watchdog.getItemState( 'editor1' ) ).to.equal( 'ready' );
 						} )
 				);
 
-				setTimeout( () => throwCKEditorError( 'foo', watchdog.get( 'editor1' ) ) );
+				setTimeout( () => throwCKEditorError( 'foo', watchdog.getItem( 'editor1' ) ) );
 
 				await waitCycle();
 

--- a/tests/contextwatchdog.js
+++ b/tests/contextwatchdog.js
@@ -35,7 +35,7 @@ describe( 'ContextWatchdog', () => {
 		sinon.restore();
 	} );
 
-	it( 'should disable adding items once the Watchdog is destroyed', async () => {
+	it( 'should disable adding items once the ContextWatchdog is destroyed', async () => {
 		watchdog = ContextWatchdog.for( Context, {} );
 
 		await watchdog.destroy();

--- a/tests/contextwatchdog.js
+++ b/tests/contextwatchdog.js
@@ -553,6 +553,7 @@ describe( 'ContextWatchdog', () => {
 				setTimeout( () => throwCKEditorError( 'foo', watchdog.get( 'editor1' ) ) );
 				setTimeout( () => throwCKEditorError( 'foo', watchdog.get( 'editor1' ) ) );
 				setTimeout( () => throwCKEditorError( 'foo', watchdog.get( 'editor1' ) ) );
+
 				await waitCycle();
 
 				expect( watchdog.getState( 'editor1' ) ).to.equal( 'crashedPermanently' );

--- a/tests/contextwatchdog.js
+++ b/tests/contextwatchdog.js
@@ -226,7 +226,7 @@ describe( 'ContextWatchdog', () => {
 			let err;
 
 			try {
-				await watchdog.remove( [ 'foo' ] );
+				await watchdog.remove( 'foo' );
 			} catch ( _err ) {
 				err = _err;
 			}
@@ -318,9 +318,7 @@ describe( 'ContextWatchdog', () => {
 				config: {}
 			} ] );
 
-			watchdog.remove( [ 'editor1' ] );
-
-			watchdog.remove( [ 'editor2' ] );
+			watchdog.remove( [ 'editor1', 'editor2' ] );
 
 			await watchdog.destroy();
 		} );
@@ -365,7 +363,7 @@ describe( 'ContextWatchdog', () => {
 			expect( watchdog.get( 'editor1' ) ).to.be.instanceOf( ClassicTestEditor );
 			expect( watchdog.get( 'editor2' ) ).to.be.instanceOf( ClassicTestEditor );
 
-			await watchdog.remove( [ 'editor1' ] );
+			await watchdog.remove( 'editor1' );
 
 			expect( () => {
 				watchdog.get( 'editor1' );
@@ -517,7 +515,7 @@ describe( 'ContextWatchdog', () => {
 
 				const editor1 = watchdog.get( 'editor1' );
 
-				const removePromise = watchdog.remove( [ 'editor1' ] );
+				const removePromise = watchdog.remove( 'editor1' );
 
 				setTimeout( () => throwCKEditorError( 'foo', editor1 ) );
 

--- a/tests/contextwatchdog.js
+++ b/tests/contextwatchdog.js
@@ -564,6 +564,64 @@ describe( 'ContextWatchdog', () => {
 
 				await watchdog.destroy();
 			} );
+
+			it( 'should rethrow item `error` events as `itemError` events', async () => {
+				watchdog = new ContextWatchdog( Context );
+
+				watchdog.create();
+
+				await watchdog.add( [ {
+					id: 'editor1',
+					type: 'editor',
+					creator: ( el, config ) => ClassicTestEditor.create( el, config ),
+					sourceElementOrData: element1,
+					config: {}
+				} ] );
+
+				const itemErrorSpy = sinon.spy();
+
+				watchdog.on( 'itemError', itemErrorSpy );
+
+				setTimeout( () => throwCKEditorError( 'foo', watchdog.get( 'editor1' ) ) );
+
+				await waitCycle();
+
+				sinon.assert.calledOnce( itemErrorSpy );
+				sinon.assert.calledWith( itemErrorSpy, sinon.match.any, sinon.match( data => {
+					return data.itemId === 'editor1';
+				} ) );
+
+				await watchdog.destroy();
+			} );
+
+			it( 'should rethrow item `restart` events as `itemRestart` events', async () => {
+				watchdog = new ContextWatchdog( Context );
+
+				watchdog.create();
+
+				await watchdog.add( [ {
+					id: 'editor1',
+					type: 'editor',
+					creator: ( el, config ) => ClassicTestEditor.create( el, config ),
+					sourceElementOrData: element1,
+					config: {}
+				} ] );
+
+				const itemRestartSpy = sinon.spy();
+
+				watchdog.on( 'itemRestart', itemRestartSpy );
+
+				setTimeout( () => throwCKEditorError( 'foo', watchdog.get( 'editor1' ) ) );
+
+				await waitCycle();
+
+				sinon.assert.calledOnce( itemRestartSpy );
+				sinon.assert.calledWith( itemRestartSpy, sinon.match.any, sinon.match( data => {
+					return data.itemId === 'editor1';
+				} ) );
+
+				await watchdog.destroy();
+			} );
 		} );
 	} );
 } );

--- a/tests/contextwatchdog.js
+++ b/tests/contextwatchdog.js
@@ -413,7 +413,7 @@ describe( 'ContextWatchdog', () => {
 
 				sinon.assert.calledOnce( restartSpy );
 
-				expect( watchdog._watchdogs.get( 'editor1' ).state ).to.equal( 'ready' );
+				expect( watchdog.getState( 'editor1' ) ).to.equal( 'ready' );
 				expect( watchdog.context ).to.not.equal( oldContext );
 
 				await watchdog.destroy();
@@ -497,8 +497,8 @@ describe( 'ContextWatchdog', () => {
 				sinon.assert.notCalled( mainWatchdogRestartSpy );
 				sinon.assert.notCalled( editorWatchdog2RestartSpy );
 
-				expect( editorWatchdog1.state ).to.equal( 'ready' );
-				expect( editorWatchdog2.state ).to.equal( 'ready' );
+				expect( watchdog.getState( 'editor1' ) ).to.equal( 'ready' );
+				expect( watchdog.getState( 'editor2' ) ).to.equal( 'ready' );
 				expect( watchdog.state ).to.equal( 'ready' );
 
 				expect( oldEditor1 ).to.not.equal( editorWatchdog1.editor );
@@ -564,15 +564,13 @@ describe( 'ContextWatchdog', () => {
 
 				await watchdog.waitForReady();
 
-				const editorWatchdog = watchdog._watchdogs.get( 'editor1' );
-
-				setTimeout( () => throwCKEditorError( 'foo', editorWatchdog.editor ) );
-				setTimeout( () => throwCKEditorError( 'foo', editorWatchdog.editor ) );
-				setTimeout( () => throwCKEditorError( 'foo', editorWatchdog.editor ) );
-				setTimeout( () => throwCKEditorError( 'foo', editorWatchdog.editor ) );
+				setTimeout( () => throwCKEditorError( 'foo', watchdog.get( 'editor1' ) ) );
+				setTimeout( () => throwCKEditorError( 'foo', watchdog.get( 'editor1' ) ) );
+				setTimeout( () => throwCKEditorError( 'foo', watchdog.get( 'editor1' ) ) );
+				setTimeout( () => throwCKEditorError( 'foo', watchdog.get( 'editor1' ) ) );
 				await waitCycle();
 
-				expect( editorWatchdog.state ).to.equal( 'crashedPermanently' );
+				expect( watchdog.getState( 'editor1' ) ).to.equal( 'crashedPermanently' );
 				expect( watchdog.state ).to.equal( 'ready' );
 
 				await watchdog.destroy();

--- a/tests/contextwatchdog.js
+++ b/tests/contextwatchdog.js
@@ -299,7 +299,7 @@ describe( 'ContextWatchdog', () => {
 			expect( err.message ).to.match( /Not supported item type: 'foo'\./ );
 		} );
 
-		it( 'should allow adding and removing items without waiting', async () => {
+		it( 'should allow adding and removing items without waiting for promises', async () => {
 			watchdog = new ContextWatchdog( Context );
 
 			watchdog.create();

--- a/tests/contextwatchdog.js
+++ b/tests/contextwatchdog.js
@@ -578,18 +578,23 @@ describe( 'ContextWatchdog', () => {
 					config: {}
 				} ] );
 
-				const itemErrorSpy = sinon.spy();
-
-				watchdog.on( 'itemError', itemErrorSpy );
+				watchdog.on(
+					'itemError',
+					sinon.mock()
+						.once()
+						.withArgs( sinon.match.any, sinon.match( data => {
+							return data.itemId === 'editor1';
+						} ) )
+						.callsFake( () => {
+							expect( watchdog.get( 'editor1' ).state ).to.equal( 'crashed' );
+						} )
+				);
 
 				setTimeout( () => throwCKEditorError( 'foo', watchdog.get( 'editor1' ) ) );
 
 				await waitCycle();
 
-				sinon.assert.calledOnce( itemErrorSpy );
-				sinon.assert.calledWith( itemErrorSpy, sinon.match.any, sinon.match( data => {
-					return data.itemId === 'editor1';
-				} ) );
+				sinon.verify();
 
 				await watchdog.destroy();
 			} );
@@ -607,18 +612,23 @@ describe( 'ContextWatchdog', () => {
 					config: {}
 				} ] );
 
-				const itemRestartSpy = sinon.spy();
-
-				watchdog.on( 'itemRestart', itemRestartSpy );
+				watchdog.on(
+					'itemRestart',
+					sinon.mock()
+						.once()
+						.withArgs( sinon.match.any, sinon.match( data => {
+							return data.itemId === 'editor1';
+						} ) )
+						.callsFake( () => {
+							expect( watchdog.get( 'editor1' ).state ).to.equal( 'ready' );
+						} )
+				);
 
 				setTimeout( () => throwCKEditorError( 'foo', watchdog.get( 'editor1' ) ) );
 
 				await waitCycle();
 
-				sinon.assert.calledOnce( itemRestartSpy );
-				sinon.assert.calledWith( itemRestartSpy, sinon.match.any, sinon.match( data => {
-					return data.itemId === 'editor1';
-				} ) );
+				sinon.verify();
 
 				await watchdog.destroy();
 			} );

--- a/tests/contextwatchdog.js
+++ b/tests/contextwatchdog.js
@@ -59,27 +59,6 @@ describe( 'ContextWatchdog', () => {
 		expect( err.message ).to.match( /Cannot add items to destroyed watchdog\./ );
 	} );
 
-	it.skip( 'case: editor, contextItem', async () => {
-		watchdog = ContextWatchdog.for( Context, {} );
-
-		watchdog.add( {
-			editor1: {
-				type: 'editor',
-				creator: ( el, config ) => ClassicTestEditor.create( el, config ),
-				sourceElementOrData: element1,
-				config: {}
-			},
-			annotatedInput: {
-				type: 'contextItem',
-				creator: () => { }
-			}
-		} );
-
-		await watchdog.waitForReady();
-
-		await watchdog.destroy();
-	} );
-
 	describe( 'for scenario with no items', () => {
 		it( 'should create only context', async () => {
 			watchdog = ContextWatchdog.for( Context, {} );

--- a/tests/contextwatchdog.js
+++ b/tests/contextwatchdog.js
@@ -43,14 +43,13 @@ describe( 'ContextWatchdog', () => {
 		let err;
 
 		try {
-			await watchdog.add( {
-				editor2: {
-					type: 'editor',
-					creator: ( el, config ) => ClassicTestEditor.create( el, config ),
-					sourceElementOrData: element1,
-					config: {}
-				},
-			} );
+			await watchdog.add( [ {
+				id: 'editor1',
+				type: 'editor',
+				creator: ( el, config ) => ClassicTestEditor.create( el, config ),
+				sourceElementOrData: element1,
+				config: {}
+			} ] );
 		} catch ( _err ) {
 			err = _err;
 		}
@@ -162,38 +161,34 @@ describe( 'ContextWatchdog', () => {
 			watchdog = ContextWatchdog.for( Context, {} );
 
 			watchdog.add( {
-				editor1: {
-					type: 'editor',
-					creator: ( el, config ) => ClassicTestEditor.create( el, config ),
-					sourceElementOrData: element1,
-					config: {}
-				},
+				id: 'editor1',
+				type: 'editor',
+				creator: ( el, config ) => ClassicTestEditor.create( el, config ),
+				sourceElementOrData: element1,
+				config: {}
+			}, {
+				id: 'editor2',
+				type: 'editor',
+				creator: ( el, config ) => ClassicTestEditor.create( el, config ),
+				sourceElementOrData: element2,
+				config: {}
 			} );
 
-			watchdog.add( {
-				editor2: {
-					type: 'editor',
-					creator: ( el, config ) => ClassicTestEditor.create( el, config ),
-					sourceElementOrData: element2,
-					config: {}
-				},
-			} );
-
+			// TODO
 			await watchdog.waitForReady();
 
 			await watchdog.destroy();
 		} );
 
-		it( 'should throw when multiple items with the same name are added', async () => {
+		it( 'should throw when multiple items with the same id are added', async () => {
 			watchdog = ContextWatchdog.for( Context, {} );
 
 			watchdog.add( {
-				editor1: {
-					type: 'editor',
-					creator: ( el, config ) => ClassicTestEditor.create( el, config ),
-					sourceElementOrData: element1,
-					config: {}
-				},
+				id: 'editor1',
+				type: 'editor',
+				creator: ( el, config ) => ClassicTestEditor.create( el, config ),
+				sourceElementOrData: element1,
+				config: {}
 			} );
 
 			await watchdog.waitForReady();
@@ -201,12 +196,11 @@ describe( 'ContextWatchdog', () => {
 			let err;
 			try {
 				await watchdog.add( {
-					editor1: {
-						type: 'editor',
-						creator: ( el, config ) => ClassicTestEditor.create( el, config ),
-						sourceElementOrData: element1,
-						config: {}
-					},
+					id: 'editor1',
+					type: 'editor',
+					creator: ( el, config ) => ClassicTestEditor.create( el, config ),
+					sourceElementOrData: element1,
+					config: {}
 				} );
 			} catch ( _err ) {
 				err = _err;
@@ -215,7 +209,7 @@ describe( 'ContextWatchdog', () => {
 			await watchdog.destroy();
 
 			expect( err ).to.be.instanceOf( Error );
-			expect( err.message ).to.match( /Item with the given name is already added: 'editor1'./ );
+			expect( err.message ).to.match( /Item with the given id is already added: 'editor1'./ );
 		} );
 
 		it( 'should throw when not added item is removed', async () => {
@@ -234,7 +228,7 @@ describe( 'ContextWatchdog', () => {
 			await watchdog.destroy();
 
 			expect( err ).to.be.instanceOf( Error );
-			expect( err.message ).to.match( /Item with the given name was not registered: foo\./ );
+			expect( err.message ).to.match( /Item with the given id was not registered: foo\./ );
 		} );
 
 		it( 'should throw when the item is added before the context is created', async () => {
@@ -259,13 +253,12 @@ describe( 'ContextWatchdog', () => {
 			const destructorSpy = sinon.spy( editor => editor.destroy() );
 
 			watchdog.add( {
-				editor1: {
-					type: 'editor',
-					creator: ( el, config ) => ClassicTestEditor.create( el, config ),
-					destructor: destructorSpy,
-					sourceElementOrData: element1,
-					config: {},
-				},
+				id: 'editor1',
+				type: 'editor',
+				creator: ( el, config ) => ClassicTestEditor.create( el, config ),
+				destructor: destructorSpy,
+				sourceElementOrData: element1,
+				config: {},
 			} );
 
 			await watchdog.destroy();
@@ -281,12 +274,11 @@ describe( 'ContextWatchdog', () => {
 			let err;
 			try {
 				await watchdog.add( {
-					editor1: {
-						type: 'foo',
-						creator: ( el, config ) => ClassicTestEditor.create( el, config ),
-						sourceElementOrData: element1,
-						config: {}
-					},
+					id: 'editor1',
+					type: 'foo',
+					creator: ( el, config ) => ClassicTestEditor.create( el, config ),
+					sourceElementOrData: element1,
+					config: {}
 				} );
 			} catch ( _err ) {
 				watchdog._stopErrorHandling();
@@ -302,23 +294,19 @@ describe( 'ContextWatchdog', () => {
 		it( 'should allow adding and removing items without waiting', async () => {
 			watchdog = ContextWatchdog.for( Context, {} );
 
-			watchdog.add( {
-				editor1: {
-					type: 'editor',
-					creator: ( el, config ) => ClassicTestEditor.create( el, config ),
-					sourceElementOrData: element1,
-					config: {}
-				},
-			} );
-
-			watchdog.add( {
-				editor2: {
-					type: 'editor',
-					creator: ( el, config ) => ClassicTestEditor.create( el, config ),
-					sourceElementOrData: element2,
-					config: {}
-				},
-			} );
+			watchdog.add( [ {
+				id: 'editor1',
+				type: 'editor',
+				creator: ( el, config ) => ClassicTestEditor.create( el, config ),
+				sourceElementOrData: element1,
+				config: {}
+			}, {
+				id: 'editor2',
+				type: 'editor',
+				creator: ( el, config ) => ClassicTestEditor.create( el, config ),
+				sourceElementOrData: element2,
+				config: {}
+			} ] );
 
 			await watchdog.waitForReady();
 
@@ -338,14 +326,13 @@ describe( 'ContextWatchdog', () => {
 		it( 'should not change the input items', async () => {
 			watchdog = ContextWatchdog.for( Context, {} );
 
-			watchdog.add( Object.freeze( {
-				editor1: {
-					type: 'editor',
-					creator: ( el, config ) => ClassicTestEditor.create( el, config ),
-					sourceElementOrData: element1,
-					config: {}
-				}
-			} ) );
+			watchdog.add( Object.freeze( [ {
+				id: 'editor1',
+				type: 'editor',
+				creator: ( el, config ) => ClassicTestEditor.create( el, config ),
+				sourceElementOrData: element1,
+				config: {}
+			} ] ) );
 
 			watchdog._restart();
 
@@ -354,23 +341,22 @@ describe( 'ContextWatchdog', () => {
 			await watchdog.destroy();
 		} );
 
-		it( 'should return the created items instances with get( itemName )', async () => {
+		it( 'should return the created items instances with ContextWatchdog#get( itemId )', async () => {
 			watchdog = ContextWatchdog.for( Context, {} );
 
-			watchdog.add( {
-				editor1: {
-					type: 'editor',
-					creator: ( el, config ) => ClassicTestEditor.create( el, config ),
-					sourceElementOrData: element1,
-					config: {}
-				},
-				editor2: {
-					type: 'editor',
-					creator: ( el, config ) => ClassicTestEditor.create( el, config ),
-					sourceElementOrData: element2,
-					config: {}
-				}
-			} );
+			watchdog.add( [ {
+				id: 'editor1',
+				type: 'editor',
+				creator: ( el, config ) => ClassicTestEditor.create( el, config ),
+				sourceElementOrData: element1,
+				config: {}
+			}, {
+				id: 'editor2',
+				type: 'editor',
+				creator: ( el, config ) => ClassicTestEditor.create( el, config ),
+				sourceElementOrData: element2,
+				config: {}
+			} ] );
 
 			await watchdog.waitForReady();
 
@@ -381,7 +367,7 @@ describe( 'ContextWatchdog', () => {
 
 			expect( () => {
 				watchdog.get( 'editor1' );
-			} ).to.throw( /Item with the given name was not registered: editor1\./ );
+			} ).to.throw( /Item with the given id was not registered: editor1\./ );
 
 			expect( watchdog.get( 'editor2' ) ).to.be.instanceOf( ClassicTestEditor );
 
@@ -391,14 +377,13 @@ describe( 'ContextWatchdog', () => {
 		describe( 'in case of error handling', () => {
 			it( 'should restart the whole structure of editors if an error happens inside the `Context`', async () => {
 				watchdog = ContextWatchdog.for( Context, {} );
-				watchdog.add( {
-					editor1: {
-						type: 'editor',
-						creator: ( el, config ) => ClassicTestEditor.create( el, config ),
-						sourceElementOrData: element1,
-						config: {}
-					}
-				} );
+				watchdog.add( [ {
+					id: 'editor1',
+					type: 'editor',
+					creator: ( el, config ) => ClassicTestEditor.create( el, config ),
+					sourceElementOrData: element1,
+					config: {}
+				} ] );
 
 				await watchdog.waitForReady();
 
@@ -422,12 +407,11 @@ describe( 'ContextWatchdog', () => {
 			it( 'should restart only the editor if an error happens inside the editor', async () => {
 				watchdog = ContextWatchdog.for( Context, {} );
 				watchdog.add( {
-					editor1: {
-						type: 'editor',
-						creator: ( el, config ) => ClassicTestEditor.create( el, config ),
-						sourceElementOrData: element1,
-						config: {}
-					}
+					id: 'editor1',
+					type: 'editor',
+					creator: ( el, config ) => ClassicTestEditor.create( el, config ),
+					sourceElementOrData: element1,
+					config: {}
 				} );
 
 				await watchdog.waitForReady();
@@ -455,20 +439,19 @@ describe( 'ContextWatchdog', () => {
 			it( 'should restart only the editor if an error happens inside one of the editors', async () => {
 				watchdog = ContextWatchdog.for( Context, {} );
 
-				watchdog.add( {
-					editor1: {
-						type: 'editor',
-						creator: ( el, config ) => ClassicTestEditor.create( el, config ),
-						sourceElementOrData: element1,
-						config: {}
-					},
-					editor2: {
-						type: 'editor',
-						creator: ( el, config ) => ClassicTestEditor.create( el, config ),
-						sourceElementOrData: element2,
-						config: {}
-					}
-				} );
+				watchdog.add( [ {
+					id: 'editor1',
+					type: 'editor',
+					creator: ( el, config ) => ClassicTestEditor.create( el, config ),
+					sourceElementOrData: element1,
+					config: {}
+				}, {
+					id: 'editor2',
+					type: 'editor',
+					creator: ( el, config ) => ClassicTestEditor.create( el, config ),
+					sourceElementOrData: element2,
+					config: {}
+				} ] );
 
 				await watchdog.waitForReady();
 
@@ -512,20 +495,19 @@ describe( 'ContextWatchdog', () => {
 			it( 'should handle removing and restarting at the same time', async () => {
 				watchdog = ContextWatchdog.for( Context, {} );
 
-				watchdog.add( {
-					editor1: {
-						type: 'editor',
-						creator: ( el, config ) => ClassicTestEditor.create( el, config ),
-						sourceElementOrData: element1,
-						config: {}
-					},
-					editor2: {
-						type: 'editor',
-						creator: ( el, config ) => ClassicTestEditor.create( el, config ),
-						sourceElementOrData: element2,
-						config: {}
-					}
-				} );
+				watchdog.add( [ {
+					id: 'editor1',
+					type: 'editor',
+					creator: ( el, config ) => ClassicTestEditor.create( el, config ),
+					sourceElementOrData: element1,
+					config: {}
+				}, {
+					id: 'editor2',
+					type: 'editor',
+					creator: ( el, config ) => ClassicTestEditor.create( el, config ),
+					sourceElementOrData: element2,
+					config: {}
+				} ] );
 
 				await watchdog.waitForReady();
 
@@ -547,20 +529,19 @@ describe( 'ContextWatchdog', () => {
 			it( 'should handle restarting the item instance many times', async () => {
 				watchdog = ContextWatchdog.for( Context, {} );
 
-				watchdog.add( {
-					editor1: {
-						type: 'editor',
-						creator: ( el, config ) => ClassicTestEditor.create( el, config ),
-						sourceElementOrData: element1,
-						config: {}
-					},
-					editor2: {
-						type: 'editor',
-						creator: ( el, config ) => ClassicTestEditor.create( el, config ),
-						sourceElementOrData: element2,
-						config: {}
-					}
-				} );
+				watchdog.add( [ {
+					id: 'editor1',
+					type: 'editor',
+					creator: ( el, config ) => ClassicTestEditor.create( el, config ),
+					sourceElementOrData: element1,
+					config: {}
+				}, {
+					id: 'editor2',
+					type: 'editor',
+					creator: ( el, config ) => ClassicTestEditor.create( el, config ),
+					sourceElementOrData: element2,
+					config: {}
+				} ] );
 
 				await watchdog.waitForReady();
 

--- a/tests/editorwatchdog.js
+++ b/tests/editorwatchdog.js
@@ -481,7 +481,7 @@ describe( 'EditorWatchdog', () => {
 			await watchdog.destroy();
 		} );
 
-		it( 'Watchdog should warn if the CKEditorError missing its context', async () => {
+		it( 'Watchdog should warn if the CKEditorError is missing its context', async () => {
 			const watchdog = new EditorWatchdog();
 
 			watchdog.setCreator( ( el, config ) => ClassicTestEditor.create( el, config ) );
@@ -533,7 +533,7 @@ describe( 'EditorWatchdog', () => {
 			await watchdog.destroy();
 		} );
 
-		it( 'editor should be restarted with the data before the crash #1', () => {
+		it( 'editor should be restarted with the data from before the crash #1', () => {
 			const watchdog = new EditorWatchdog();
 
 			watchdog.setCreator( ( el, config ) => ClassicTestEditor.create( el, config ) );

--- a/tests/editorwatchdog.js
+++ b/tests/editorwatchdog.js
@@ -10,7 +10,6 @@ import Editor from '@ckeditor/ckeditor5-core/src/editor/editor';
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
-import { assertCKEditorError } from '@ckeditor/ckeditor5-utils/tests/_utils/utils';
 import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/htmldataprocessor';
 
 // The error handling testing with mocha & chai is quite broken and hard to test.
@@ -47,16 +46,6 @@ describe( 'EditorWatchdog', () => {
 
 			sinon.assert.calledOnce( editorCreateSpy );
 			sinon.assert.calledOnce( editorDestroySpy );
-		} );
-
-		it( 'should throw an error when the creator is not defined', async () => {
-			const watchdog = new EditorWatchdog();
-
-			try {
-				await watchdog.create();
-			} catch ( err ) {
-				assertCKEditorError( err, /^watchdog-creator-not-defined/, null );
-			}
 		} );
 
 		it( 'should properly copy the config', async () => {
@@ -107,7 +96,7 @@ describe( 'EditorWatchdog', () => {
 
 	describe( 'editor', () => {
 		it( 'should be the current editor instance', () => {
-			const watchdog = EditorWatchdog.for( ClassicTestEditor );
+			const watchdog = new EditorWatchdog( ClassicTestEditor );
 
 			// sinon.stub( window, 'onerror' ).value( undefined ); and similar do not work.
 			const originalErrorHandler = window.onerror;
@@ -146,7 +135,7 @@ describe( 'EditorWatchdog', () => {
 
 	describe( 'error handling', () => {
 		it( 'Watchdog should not restart editor during the initialization', () => {
-			const watchdog = new EditorWatchdog();
+			const watchdog = new EditorWatchdog( ClassicTestEditor );
 			let editor;
 
 			watchdog.setCreator( async el => {
@@ -166,9 +155,8 @@ describe( 'EditorWatchdog', () => {
 		} );
 
 		it( 'Watchdog should not restart editor during the destroy', async () => {
-			const watchdog = new EditorWatchdog();
+			const watchdog = new EditorWatchdog( ClassicTestEditor );
 
-			watchdog.setCreator( el => ClassicTestEditor.create( el ) );
 			watchdog.setDestructor( () => Promise.reject( new Error( 'foo' ) ) );
 
 			await watchdog.create( element );
@@ -192,9 +180,7 @@ describe( 'EditorWatchdog', () => {
 		} );
 
 		it( 'Watchdog should not hide intercepted errors', () => {
-			const watchdog = new EditorWatchdog();
-
-			watchdog.setCreator( ( el, config ) => ClassicTestEditor.create( el, config ) );
+			const watchdog = new EditorWatchdog( ClassicTestEditor );
 
 			// sinon.stub( window, 'onerror' ).value( undefined ); and similar do not work.
 			const originalErrorHandler = window.onerror;
@@ -220,9 +206,7 @@ describe( 'EditorWatchdog', () => {
 		} );
 
 		it( 'Watchdog should intercept editor errors and restart the editor during the runtime', () => {
-			const watchdog = new EditorWatchdog();
-
-			watchdog.setCreator( ( el, config ) => ClassicTestEditor.create( el, config ) );
+			const watchdog = new EditorWatchdog( ClassicTestEditor );
 
 			// sinon.stub( window, 'onerror' ).value( undefined ); and similar do not work.
 			const originalErrorHandler = window.onerror;
@@ -242,9 +226,7 @@ describe( 'EditorWatchdog', () => {
 		} );
 
 		it( 'Watchdog should not intercept non-editor errors', () => {
-			const watchdog = new EditorWatchdog();
-
-			watchdog.setCreator( ( el, config ) => ClassicTestEditor.create( el, config ) );
+			const watchdog = new EditorWatchdog( ClassicTestEditor );
 
 			const editorErrorSpy = sinon.spy();
 			watchdog.on( 'error', editorErrorSpy );
@@ -287,8 +269,8 @@ describe( 'EditorWatchdog', () => {
 		} );
 
 		it( 'Watchdog should not intercept other editor errors', () => {
-			const watchdog1 = EditorWatchdog.for( ClassicTestEditor );
-			const watchdog2 = EditorWatchdog.for( ClassicTestEditor );
+			const watchdog1 = new EditorWatchdog( ClassicTestEditor );
+			const watchdog2 = new EditorWatchdog( ClassicTestEditor );
 
 			const config = {
 				plugins: []
@@ -325,9 +307,7 @@ describe( 'EditorWatchdog', () => {
 		} );
 
 		it( 'Watchdog should intercept editor errors and restart the editor if the editor can be found from the context', async () => {
-			const watchdog = new EditorWatchdog();
-
-			watchdog.setCreator( ( el, config ) => ClassicTestEditor.create( el, config ) );
+			const watchdog = new EditorWatchdog( ClassicTestEditor );
 
 			// sinon.stub( window, 'onerror' ).value( undefined ); and similar do not work.
 			const originalErrorHandler = window.onerror;
@@ -347,9 +327,7 @@ describe( 'EditorWatchdog', () => {
 		} );
 
 		it( 'Watchdog should intercept editor errors and restart the editor if the editor can be found from the context #2', async () => {
-			const watchdog = new EditorWatchdog();
-
-			watchdog.setCreator( ( el, config ) => ClassicTestEditor.create( el, config ) );
+			const watchdog = new EditorWatchdog( ClassicTestEditor );
 
 			// sinon.stub( window, 'onerror' ).value( undefined ); and similar do not work.
 			const originalErrorHandler = window.onerror;
@@ -379,9 +357,7 @@ describe( 'EditorWatchdog', () => {
 
 		it( 'Watchdog should crash permanently if the `crashNumberLimit` is reached' +
 			' and the average time between errors is lower than `minimumNonErrorTimePeriod` (default values)', async () => {
-			const watchdog = new EditorWatchdog();
-
-			watchdog.setCreator( ( el, config ) => ClassicTestEditor.create( el, config ) );
+			const watchdog = new EditorWatchdog( ClassicTestEditor );
 
 			const errorSpy = sinon.spy();
 			watchdog.on( 'error', errorSpy );
@@ -413,9 +389,7 @@ describe( 'EditorWatchdog', () => {
 
 		it( 'Watchdog should crash permanently if the `crashNumberLimit` is reached' +
 			' and the average time between errors is lower than `minimumNonErrorTimePeriod` (custom values)', async () => {
-			const watchdog = new EditorWatchdog( { crashNumberLimit: 2, minimumNonErrorTimePeriod: 1000 } );
-
-			watchdog.setCreator( ( el, config ) => ClassicTestEditor.create( el, config ) );
+			const watchdog = new EditorWatchdog( ClassicTestEditor, { crashNumberLimit: 2, minimumNonErrorTimePeriod: 1000 } );
 
 			const errorSpy = sinon.spy();
 			watchdog.on( 'error', errorSpy );
@@ -447,9 +421,7 @@ describe( 'EditorWatchdog', () => {
 
 		it( 'Watchdog should not crash permanently when average time between errors' +
 			' is longer than `minimumNonErrorTimePeriod`', async () => {
-			const watchdog = new EditorWatchdog( { crashNumberLimit: 2, minimumNonErrorTimePeriod: 0 } );
-
-			watchdog.setCreator( ( el, config ) => ClassicTestEditor.create( el, config ) );
+			const watchdog = new EditorWatchdog( ClassicTestEditor, { crashNumberLimit: 2, minimumNonErrorTimePeriod: 0 } );
 
 			const errorSpy = sinon.spy();
 			watchdog.on( 'error', errorSpy );
@@ -482,10 +454,7 @@ describe( 'EditorWatchdog', () => {
 		} );
 
 		it( 'Watchdog should warn if the CKEditorError is missing its context', async () => {
-			const watchdog = new EditorWatchdog();
-
-			watchdog.setCreator( ( el, config ) => ClassicTestEditor.create( el, config ) );
-			watchdog.setDestructor( editor => editor.destroy() );
+			const watchdog = new EditorWatchdog( ClassicTestEditor );
 
 			// sinon.stub( window, 'onerror' ).value( undefined ); and similar do not work.
 			const originalErrorHandler = window.onerror;
@@ -512,9 +481,7 @@ describe( 'EditorWatchdog', () => {
 		} );
 
 		it( 'Watchdog should omit error if the CKEditorError context is equal to null', async () => {
-			const watchdog = new EditorWatchdog();
-
-			watchdog.setCreator( ( el, config ) => ClassicTestEditor.create( el, config ) );
+			const watchdog = new EditorWatchdog( ClassicTestEditor );
 
 			// sinon.stub( window, 'onerror' ).value( undefined ); and similar do not work.
 			const originalErrorHandler = window.onerror;
@@ -534,9 +501,7 @@ describe( 'EditorWatchdog', () => {
 		} );
 
 		it( 'editor should be restarted with the data from before the crash #1', () => {
-			const watchdog = new EditorWatchdog();
-
-			watchdog.setCreator( ( el, config ) => ClassicTestEditor.create( el, config ) );
+			const watchdog = new EditorWatchdog( ClassicTestEditor );
 
 			// sinon.stub( window, 'onerror' ).value( undefined ); and similar do not work.
 			const originalErrorHandler = window.onerror;
@@ -561,9 +526,7 @@ describe( 'EditorWatchdog', () => {
 		} );
 
 		it( 'editor should be restarted with the data before the crash #2', () => {
-			const watchdog = new EditorWatchdog();
-
-			watchdog.setCreator( ( el, config ) => ClassicTestEditor.create( el, config ) );
+			const watchdog = new EditorWatchdog( ClassicTestEditor );
 
 			// sinon.stub( window, 'onerror' ).value( undefined ); and similar do not work.
 			const originalErrorHandler = window.onerror;
@@ -594,9 +557,7 @@ describe( 'EditorWatchdog', () => {
 		} );
 
 		it( 'editor should be restarted with the data of the latest document version before the crash', () => {
-			const watchdog = new EditorWatchdog();
-
-			watchdog.setCreator( ( el, config ) => ClassicTestEditor.create( el, config ) );
+			const watchdog = new EditorWatchdog( ClassicTestEditor );
 
 			// sinon.stub( window, 'onerror' ).value( undefined ); and similar do not work.
 			const originalErrorHandler = window.onerror;
@@ -632,9 +593,7 @@ describe( 'EditorWatchdog', () => {
 		} );
 
 		it( 'editor should be restarted with the latest available data before the crash', async () => {
-			const watchdog = new EditorWatchdog();
-
-			watchdog.setCreator( ( el, config ) => ClassicTestEditor.create( el, config ) );
+			const watchdog = new EditorWatchdog( ClassicTestEditor );
 
 			// sinon.stub( window, 'onerror' ).value( undefined ); and similar do not work.
 			const originalErrorHandler = window.onerror;
@@ -695,10 +654,9 @@ describe( 'EditorWatchdog', () => {
 		} );
 
 		it( 'should use the custom destructor if passed', () => {
-			const watchdog = new EditorWatchdog();
+			const watchdog = new EditorWatchdog( ClassicTestEditor );
 			const destructionSpy = sinon.spy();
 
-			watchdog.setCreator( ( el, config ) => ClassicTestEditor.create( el, config ) );
 			watchdog.setDestructor( editor => {
 				destructionSpy();
 				return editor.destroy();
@@ -739,7 +697,7 @@ describe( 'EditorWatchdog', () => {
 				return;
 			}
 
-			const watchdog = EditorWatchdog.for( ClassicTestEditor );
+			const watchdog = new EditorWatchdog( ClassicTestEditor );
 			const originalErrorHandler = window.onerror;
 
 			window.onerror = undefined;
@@ -770,7 +728,7 @@ describe( 'EditorWatchdog', () => {
 				return;
 			}
 
-			const watchdog = EditorWatchdog.for( ClassicTestEditor );
+			const watchdog = new EditorWatchdog( ClassicTestEditor );
 			const originalErrorHandler = window.onerror;
 			const editorErrorSpy = sinon.spy();
 
@@ -805,7 +763,7 @@ describe( 'EditorWatchdog', () => {
 			// This will ensure that the second data save action will be put off in time.
 			const SAVE_INTERVAL = 30;
 
-			const watchdog = EditorWatchdog.for( ClassicTestEditor, {
+			const watchdog = new EditorWatchdog( ClassicTestEditor, {
 				saveInterval: SAVE_INTERVAL,
 			} );
 
@@ -836,41 +794,9 @@ describe( 'EditorWatchdog', () => {
 		} );
 	} );
 
-	describe( 'static for()', () => {
-		it( 'should be a shortcut method for creating the watchdog', () => {
-			const watchdog = EditorWatchdog.for( ClassicTestEditor );
-
-			// sinon.stub( window, 'onerror' ).value( undefined ); and similar do not work.
-			const originalErrorHandler = window.onerror;
-			window.onerror = undefined;
-
-			return watchdog.create( element, {
-				initialData: '<p>foo</p>',
-				plugins: [ Paragraph ]
-			} ).then( () => {
-				const oldEditor = watchdog.editor;
-				expect( watchdog.editor ).to.be.an.instanceOf( ClassicTestEditor );
-
-				setTimeout( () => throwCKEditorError( 'foo', watchdog.editor ) );
-
-				return new Promise( res => {
-					watchdog.on( 'restart', () => {
-						window.onerror = originalErrorHandler;
-
-						expect( watchdog.editor ).to.be.an.instanceOf( ClassicTestEditor );
-						expect( watchdog.editor ).to.not.equal( oldEditor );
-						expect( watchdog.editor.getData() ).to.equal( '<p>foo</p>' );
-
-						watchdog.destroy().then( res );
-					} );
-				} );
-			} );
-		} );
-	} );
-
 	describe( 'crashes', () => {
 		it( 'should be an array of caught errors by the watchdog', () => {
-			const watchdog = EditorWatchdog.for( ClassicTestEditor );
+			const watchdog = new EditorWatchdog( ClassicTestEditor );
 
 			// sinon.stub( window, 'onerror' ).value( undefined ); and similar do not work.
 			const originalErrorHandler = window.onerror;
@@ -905,7 +831,7 @@ describe( 'EditorWatchdog', () => {
 					return;
 				}
 
-				const watchdog = EditorWatchdog.for( ClassicTestEditor );
+				const watchdog = new EditorWatchdog( ClassicTestEditor );
 
 				// sinon.stub( window, 'onerror' ).value( undefined ); and similar do not work.
 				const originalErrorHandler = window.onerror;
@@ -946,7 +872,7 @@ describe( 'EditorWatchdog', () => {
 		} );
 
 		it( 'should reflect the state of the watchdog', async () => {
-			const watchdog = EditorWatchdog.for( ClassicTestEditor );
+			const watchdog = new EditorWatchdog( ClassicTestEditor );
 
 			// sinon.stub( window, 'onerror' ).value( undefined ); and similar do not work.
 			const originalErrorHandler = window.onerror;
@@ -976,7 +902,7 @@ describe( 'EditorWatchdog', () => {
 		} );
 
 		it( 'should be observable', async () => {
-			const watchdog = EditorWatchdog.for( ClassicTestEditor );
+			const watchdog = new EditorWatchdog( ClassicTestEditor );
 			const states = [];
 
 			watchdog.on( 'change:state', ( evt, propName, newValue ) => {
@@ -1052,7 +978,7 @@ describe( 'EditorWatchdog', () => {
 				}
 			}
 
-			const watchdog = EditorWatchdog.for( MultiRootEditor );
+			const watchdog = new EditorWatchdog( MultiRootEditor );
 
 			// sinon.stub( window, 'onerror' ).value( undefined ); and similar do not work.
 			const originalErrorHandler = window.onerror;

--- a/tests/editorwatchdog.js
+++ b/tests/editorwatchdog.js
@@ -1069,11 +1069,17 @@ describe( 'EditorWatchdog', () => {
 
 			expect( watchdog.editor.data.get( { rootName: 'header' } ) ).to.equal( '<p>Foo</p>' );
 
+			const restartSpy = sinon.spy();
+
+			watchdog.on( 'restart', restartSpy );
+
 			setTimeout( () => throwCKEditorError( 'foo', watchdog.editor ) );
 
 			await waitCycle();
 
 			window.onerror = originalErrorHandler;
+
+			sinon.assert.calledOnce( restartSpy );
 
 			expect( watchdog.editor.data.get( { rootName: 'header' } ) ).to.equal( '<p>Foo</p>' );
 

--- a/tests/editorwatchdog.js
+++ b/tests/editorwatchdog.js
@@ -474,7 +474,7 @@ describe( 'EditorWatchdog', () => {
 
 			sinon.assert.calledWithExactly(
 				console.warn,
-				'The error is missing its context and Watchdog cannot restart the proper instance.'
+				'The error is missing its context and Watchdog cannot restart the proper item.'
 			);
 
 			await watchdog.destroy();

--- a/tests/editorwatchdog.js
+++ b/tests/editorwatchdog.js
@@ -1026,7 +1026,7 @@ describe( 'EditorWatchdog', () => {
 	} );
 
 	describe( 'multi-root editors', () => {
-		it( 'should support multi-root editors', () => {
+		it( 'should support multi-root editors', async () => {
 			class MultiRootEditor extends Editor {
 				constructor( sourceElements, config ) {
 					super( config );
@@ -1058,29 +1058,26 @@ describe( 'EditorWatchdog', () => {
 			const originalErrorHandler = window.onerror;
 			window.onerror = undefined;
 
-			return watchdog
-				.create( {
-					header: element
-				}, {
-					initialData: {
-						header: '<p>Foo</p>'
-					},
-					plugins: [ Paragraph ]
-				} )
-				.then( () => {
-					expect( watchdog.editor.data.get( { rootName: 'header' } ) ).to.equal( '<p>Foo</p>' );
+			await watchdog.create( {
+				header: element
+			}, {
+				initialData: {
+					header: '<p>Foo</p>'
+				},
+				plugins: [ Paragraph ]
+			} );
 
-					setTimeout( () => throwCKEditorError( 'foo', watchdog.editor ) );
+			expect( watchdog.editor.data.get( { rootName: 'header' } ) ).to.equal( '<p>Foo</p>' );
 
-					return new Promise( res => {
-						window.onerror = originalErrorHandler;
-						expect( watchdog.editor.data.get( { rootName: 'header' } ) ).to.equal( '<p>Foo</p>' );
+			setTimeout( () => throwCKEditorError( 'foo', watchdog.editor ) );
 
-						res();
-					} );
-				} ).then( () => {
-					return watchdog.destroy();
-				} );
+			await waitCycle();
+
+			window.onerror = originalErrorHandler;
+
+			expect( watchdog.editor.data.get( { rootName: 'header' } ) ).to.equal( '<p>Foo</p>' );
+
+			await watchdog.destroy();
 		} );
 	} );
 } );

--- a/tests/editorwatchdog.js
+++ b/tests/editorwatchdog.js
@@ -639,7 +639,7 @@ describe( 'EditorWatchdog', () => {
 
 					sinon.assert.calledWith(
 						console.error,
-						'An error happened during the editor destructing.'
+						'An error happened during the editor destroying.'
 					);
 
 					await watchdog.destroy();

--- a/tests/manual/watchdog.js
+++ b/tests/manual/watchdog.js
@@ -63,7 +63,7 @@ document.getElementById( 'random-error' ).addEventListener( 'click', () => {
 } );
 
 function createWatchdog( editorElement, stateElement, name ) {
-	const watchdog = EditorWatchdog.for( ClassicEditor );
+	const watchdog = new EditorWatchdog( ClassicEditor );
 
 	watchdog.create( editorElement, editorConfig );
 

--- a/tests/utils/areconnectedthroughproperties.js
+++ b/tests/utils/areconnectedthroughproperties.js
@@ -5,7 +5,7 @@
 
 /* globals window, document, Event */
 
-import areConnectedThroughProperties from '../src/utils/areconnectedthroughproperties';
+import areConnectedThroughProperties from '../../src/utils/areconnectedthroughproperties';
 
 describe( 'areConnectedThroughProperties()', () => {
 	it( 'should return `false` if one of the value is primitive #1', () => {

--- a/tests/watchdog.js
+++ b/tests/watchdog.js
@@ -16,7 +16,7 @@ describe( 'Watchdog', () => {
 	it( 'should be created using the inheritance', () => {
 		class FooWatchdog extends Watchdog {
 			_restart() {}
-			_isErrorComingFromThisInstance() {}
+			_isErrorComingFromThisItem() {}
 		}
 
 		expect( () => {

--- a/tests/watchdog.js
+++ b/tests/watchdog.js
@@ -9,7 +9,7 @@ describe( 'Watchdog', () => {
 	it( 'should not be created directly', () => {
 		expect( () => {
 			// eslint-disable-next-line no-unused-vars
-			const watchdog = new Watchdog();
+			const watchdog = new Watchdog( {} );
 		} ).to.throw( /Please, use `EditorWatchdog` if you have used the `Watchdog` class previously\./ );
 	} );
 
@@ -21,7 +21,7 @@ describe( 'Watchdog', () => {
 
 		expect( () => {
 			// eslint-disable-next-line no-unused-vars
-			const fooWatchdog = new FooWatchdog();
+			const fooWatchdog = new FooWatchdog( {} );
 		} ).to.not.throw();
 	} );
 } );

--- a/tests/watchdog.js
+++ b/tests/watchdog.js
@@ -1,0 +1,27 @@
+/**
+ * @license Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+import Watchdog from '../src/watchdog';
+
+describe( 'Watchdog', () => {
+	it( 'should not be created directly', () => {
+		expect( () => {
+			// eslint-disable-next-line no-unused-vars
+			const watchdog = new Watchdog();
+		} ).to.throw( /Please, use `EditorWatchdog` if you have used the `Watchdog` class previously\./ );
+	} );
+
+	it( 'should be created using the inheritance', () => {
+		class FooWatchdog extends Watchdog {
+			_restart() {}
+			_isErrorComingFromThisInstance() {}
+		}
+
+		expect( () => {
+			// eslint-disable-next-line no-unused-vars
+			const fooWatchdog = new FooWatchdog();
+		} ).to.not.throw();
+	} );
+} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Introduce the `ContextWatchdog` which will be a new watchdog for the `Context` feature and the main watchdog for multi-editor scenarios sharing the `Context` instance. Closes ckeditor/ckeditor5#6079. Closes [https://github.com/ckeditor/ckeditor5/issues/6042](https://github.com/ckeditor/ckeditor5/issues/6042). Closes [https://github.com/ckeditor/ckeditor5/issues/4696](https://github.com/ckeditor/ckeditor5/issues/4696).

---

### TODO:

*   [x] Should the `Watchdog` be renamed to `EditorWatchdog`? This would be a BC (But we'll have other BC anyway in this release in this package).
*   [x] Make sure that the instance of the base abstract Watchdog class won't be created by mistake.
*   [ ] State management in the ContextWatchdog needs more tests
*   [x] How the ContextWatchdog should treat the Watchdog's configuration (minimumNonErrorTimePeriod, crashNumberLimit) in case of many internal watchdogs and the main one (IMO that the crash number limit configuration should be kept for all instances together).
*   [x] Docs
*   [x] Should the `remove` accept array of strings and string?

### Additional information

BREAKING CHANGE: The `Watchdog` class was renamed to the `EditorWatchdog` class and is available in the `src/editorwatchdog.js` file.  
BREAKING CHANGE: The `EditorWatchdog.for()` method was removed in favor of the constructor.  
BREAKING CHANGE: The `EditorWatchdog#constructor()` API changed, now the `EditorWatchdog` accepts the editor class as the first argument and the watchdog configuration as the second argument.  
The `EditorWatchdog` editor creator now defaults to `(sourceElementOrData, config ) => Editor.create( sourceElementOrData, config )`

Side note: I duplicated the `getSubNodes()` and `areConnectedThroughProperties()` functions and copied and modified them in the Watchdog repository having [https://github.com/ckeditor/ckeditor5/issues/4699](https://github.com/ckeditor/ckeditor5/issues/4699) in mind.