### PR TITLE
Added integration tests for editors sharing props

### DIFF
--- a/tests/utils/areconnectedthroughproperties.js
+++ b/tests/utils/areconnectedthroughproperties.js
@@ -6,6 +6,7 @@
 /* globals window, document, Event */
 
 import areConnectedThroughProperties from '../../src/utils/areconnectedthroughproperties';
+import Editor from '@ckeditor/ckeditor5-core/src/editor/editor';
 
 describe( 'areConnectedThroughProperties()', () => {
 	it( 'should return `false` if one of the value is primitive #1', () => {
@@ -246,5 +247,55 @@ describe( 'areConnectedThroughProperties()', () => {
 		const el2 = { defaultValue: shared, shared };
 
 		expect( areConnectedThroughProperties( el1, el2 ) ).to.be.true;
+	} );
+
+	describe( 'integration tests', () => {
+		it( 'should return false for two different editors', () => {
+			const editor1 = new Editor( {} );
+			const editor2 = new Editor( {} );
+
+			expect( areConnectedThroughProperties( editor1, editor2 ) ).to.be.false;
+		} );
+
+		it( 'should return false for two different editors sharing builtin plugins', () => {
+			class FakePlugin {}
+
+			Editor.builtinPlugins = [ FakePlugin ];
+
+			const editor1 = new Editor();
+			const editor2 = new Editor();
+
+			expect( areConnectedThroughProperties( editor1, editor2 ) ).to.be.false;
+
+			delete Editor.builtinPlugins;
+		} );
+
+		it( 'should return false for two different editors inheriting default configuration', () => {
+			Editor.defaultConfig = {
+				foo: {
+					bar: []
+				}
+			};
+
+			const editor1 = new Editor();
+			const editor2 = new Editor();
+
+			expect( areConnectedThroughProperties( editor1, editor2 ) ).to.be.false;
+
+			delete Editor.defaultConfig;
+		} );
+
+		it( 'should return false for two different editors sharing builtin plugins', () => {
+			Editor.builtinPlugins = [
+				class Foo {}
+			];
+
+			const editor1 = new Editor();
+			const editor2 = new Editor();
+
+			expect( areConnectedThroughProperties( editor1, editor2 ) ).to.be.false;
+
+			delete Editor.builtinPlugins;
+		} );
 	} );
 } );

--- a/tests/utils/areconnectedthroughproperties.js
+++ b/tests/utils/areconnectedthroughproperties.js
@@ -250,6 +250,11 @@ describe( 'areConnectedThroughProperties()', () => {
 	} );
 
 	describe( 'integration tests', () => {
+		afterEach( () => {
+			delete Editor.builtinPlugins;
+			delete Editor.defaultConfig;
+		} );
+
 		it( 'should return false for two different editors', () => {
 			const editor1 = new Editor( {} );
 			const editor2 = new Editor( {} );
@@ -266,8 +271,6 @@ describe( 'areConnectedThroughProperties()', () => {
 			const editor2 = new Editor();
 
 			expect( areConnectedThroughProperties( editor1, editor2 ) ).to.be.false;
-
-			delete Editor.builtinPlugins;
 		} );
 
 		it( 'should return false for two different editors inheriting default configuration', () => {
@@ -281,8 +284,6 @@ describe( 'areConnectedThroughProperties()', () => {
 			const editor2 = new Editor();
 
 			expect( areConnectedThroughProperties( editor1, editor2 ) ).to.be.false;
-
-			delete Editor.defaultConfig;
 		} );
 
 		it( 'should return false for two different editors sharing builtin plugins', () => {
@@ -294,8 +295,6 @@ describe( 'areConnectedThroughProperties()', () => {
 			const editor2 = new Editor();
 
 			expect( areConnectedThroughProperties( editor1, editor2 ) ).to.be.false;
-
-			delete Editor.builtinPlugins;
 		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Tests: Added integration tests for editors sharing props. Closes ckeditor/ckeditor5#6219.

---

### Additional information

Requires:
- https://github.com/ckeditor/ckeditor5-utils/pull/324
- https://github.com/ckeditor/ckeditor5-core/pull/215

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
